### PR TITLE
Optimize startup, large folders, thumbnails, and video initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Speed up large masonry layouts, thumbnail cache lookups, cached-thumbnail assignment, and repeated video-skin menu construction
 - Create the main video player and controls on the first video instead of during image-only startup, and defer OpenCV until an exact-frame or deep-validation fallback needs it
 - Share and lazily create spell-check dictionaries, and load grammar-checking support only when grammar checking is invoked
-- Populate previously inspected YOLO categories without loading the model, and reuse unchanged model runtimes across Auto-Markings and repeated pipeline runs
+- Populate previously inspected YOLO categories automatically without panel interaction or model loading, and reuse unchanged model runtimes across Auto-Markings and repeated pipeline runs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to TagGUI Video 1M are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-07-18
+
+### Added
+
+- Preserve responsive Auto-Markings categories and reuse models across repeated pipeline runs
+
+### Changed
+
+- Improve startup and interactive responsiveness
+- Improve startup by loading optional features only when needed
+- Improve large indexed folders, masonry layouts, thumbnails, and repeated skin menus
+
+### Fixed
+
+- Introduce performance architecture documentation and focused regression coverage
+- Fix image deletion before video controls have been initialized
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Prevent fast thumbnail completions from leaving stale futures or an older task from removing a newer task for the same row
 - Preserve lazy caption-model resolution without circular runtime imports
+- Stop startup restoration and repeated selection signals from constructing duplicate Auto-Markings ONNX sessions
 
 ## [1.4.2] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Add regression coverage for lazy startup dependencies, deferred video components, masonry layout behavior, thumbnail task bookkeeping, and skin-catalog caching
 - Add a technical performance guide documenting the optimized boundaries, measured results, tradeoffs, and release checklist
+- Add a file-signature-aware Auto-Markings class metadata cache and a shared in-session model runtime cache
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Speed up large masonry layouts, thumbnail cache lookups, cached-thumbnail assignment, and repeated video-skin menu construction
 - Create the main video player and controls on the first video instead of during image-only startup, and defer OpenCV until an exact-frame or deep-validation fallback needs it
 - Share and lazily create spell-check dictionaries, and load grammar-checking support only when grammar checking is invoked
+- Populate previously inspected YOLO categories without loading the model, and reuse unchanged model runtimes across Auto-Markings and repeated pipeline runs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to TagGUI Video 1M are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add regression coverage for lazy startup dependencies, deferred video components, masonry layout behavior, thumbnail task bookkeeping, and skin-catalog caching
+- Add a technical performance guide documenting the optimized boundaries, measured results, tradeoffs, and release checklist
+
+### Changed
+
+- Reduce normal GUI startup work by deferring machine-learning frameworks, optional video backends, media metadata libraries, command-only dialogs, hidden workflow widgets, and secondary-window modules until their features are used
+- Restore cached large folders from the first page immediately, warm later pages in the background, and avoid materializing every indexed path when an unchanged directory signature is sufficient
+- Speed up large masonry layouts, thumbnail cache lookups, cached-thumbnail assignment, and repeated video-skin menu construction
+- Create the main video player and controls on the first video instead of during image-only startup, and defer OpenCV until an exact-frame or deep-validation fallback needs it
+- Share and lazily create spell-check dictionaries, and load grammar-checking support only when grammar checking is invoked
+
+### Fixed
+
+- Prevent fast thumbnail completions from leaving stale futures or an older task from removing a newer task for the same row
+- Preserve lazy caption-model resolution without circular runtime imports
+
 ## [1.4.2] - 2026-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Prevent fast thumbnail completions from leaving stale futures or an older task from removing a newer task for the same row
 - Preserve lazy caption-model resolution without circular runtime imports
-- Stop startup restoration and repeated selection signals from constructing duplicate Auto-Markings ONNX sessions; load the saved model and its categories on the first genuine panel interaction
+- Stop startup restoration and repeated category reads from constructing duplicate Auto-Markings ONNX sessions; prepare the saved model asynchronously on the first genuine panel interaction
 
 ## [1.4.2] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Prevent fast thumbnail completions from leaving stale futures or an older task from removing a newer task for the same row
 - Preserve lazy caption-model resolution without circular runtime imports
-- Stop startup restoration and repeated selection signals from constructing duplicate Auto-Markings ONNX sessions, and scan the model directory only when its selector is opened
+- Stop startup restoration and repeated selection signals from constructing duplicate Auto-Markings ONNX sessions; load the saved model and its categories on the first genuine panel interaction
 
 ## [1.4.2] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Prevent fast thumbnail completions from leaving stale futures or an older task from removing a newer task for the same row
 - Preserve lazy caption-model resolution without circular runtime imports
 - Stop startup restoration and repeated category reads from constructing duplicate Auto-Markings ONNX sessions; prepare the saved model asynchronously on the first genuine panel interaction
+- Allow image deletion before the lazy video player has been constructed
 
 ## [1.4.2] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- Reduce normal GUI startup work by deferring machine-learning frameworks, optional video backends, media metadata libraries, command-only dialogs, hidden workflow widgets, and secondary-window modules until their features are used
+- Reduce normal GUI startup work by deferring machine-learning frameworks, Hugging Face cache discovery, optional video backends, media metadata libraries, command-only dialogs, hidden workflow widgets, and secondary-window modules until their features are used
 - Restore cached large folders from the first page immediately, warm later pages in the background, and avoid materializing every indexed path when an unchanged directory signature is sufficient
 - Speed up large masonry layouts, thumbnail cache lookups, cached-thumbnail assignment, and repeated video-skin menu construction
 - Create the main video player and controls on the first video instead of during image-only startup, and defer OpenCV until an exact-frame or deep-validation fallback needs it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Prevent fast thumbnail completions from leaving stale futures or an older task from removing a newer task for the same row
 - Preserve lazy caption-model resolution without circular runtime imports
-- Stop startup restoration and repeated selection signals from constructing duplicate Auto-Markings ONNX sessions
+- Stop startup restoration and repeated selection signals from constructing duplicate Auto-Markings ONNX sessions, and scan the model directory only when its selector is opened
 
 ## [1.4.2] - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Stars](https://img.shields.io/github/stars/diodiogod/taggui-video?style=for-the-badge)](https://github.com/diodiogod/taggui-video/stargazers)
 [![Issues](https://img.shields.io/github/issues/diodiogod/taggui-video?style=for-the-badge)](https://github.com/diodiogod/taggui-video/issues)
 [![Forks](https://img.shields.io/github/forks/diodiogod/taggui-video?style=for-the-badge)](https://github.com/diodiogod/taggui-video/network/members)
-[![Version](https://img.shields.io/badge/version-1.4.2-1f6feb?style=for-the-badge)](https://github.com/diodiogod/taggui-video)
+[![Version](https://img.shields.io/badge/version-1.4.3-1f6feb?style=for-the-badge)](https://github.com/diodiogod/taggui-video)
 [![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/diogogo)
 
-# TagGUI Video 1M v1.4.2
+# TagGUI Video 1M v1.4.3
 
 <p align="center">
   <img src="images/icon.png" alt="TagGUI Video 1M icon" width="96">

--- a/docs/HUB.md
+++ b/docs/HUB.md
@@ -40,5 +40,6 @@ This is the main documentation map for TagGUI Video 1M.
 ## Technical References
 
 - [Startup Flags](STARTUP_FLAGS.md)
+- [Performance Architecture and Verification](PERFORMANCE_OPTIMIZATIONS.md)
 - [Skin README](../taggui/skins/README.md)
 - [Skin Property Reference](../taggui/skins/PROPERTY_REFERENCE.md)

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -91,3 +91,5 @@
 - Restored automatic YOLO category population on the first real mouse, key, or wheel interaction anywhere in Auto-Markings; startup show/focus events remain ignored, and Start reuses the prepared session.
 - Traced three identical ONNX loads to three UI-side `YOLO.names` reads during category-table construction; Ultralytics can initialize the backend through that property.
 - Moved model preparation and the first category lookup to a single guarded worker job, cached the category snapshot, and made overlapping panel/selector/Start requests share the same in-flight load.
+- Added a persistent Auto-Markings class metadata cache keyed by resolved path, size, and modification time, allowing category UI to populate without constructing a model runtime.
+- Added a shared in-memory model runtime cache used by Auto-Markings and pipeline `MarkingThread` instances; unchanged models load once per application session and inference is serialized per shared runtime.

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -88,3 +88,4 @@
 - Traced repeated Ultralytics startup messages to the delayed Auto-Markings selection restore: it called `prepare_generation()`, created a real ONNX Runtime GPU session, and selection signals could repeat that work.
 - Removed startup model preloading, made selection changes bookkeeping-only, loaded models on explicit activation or Start, and reused an already prepared matching session.
 - Removed the remaining six-second Auto-Markings directory-scan timer; recursive model discovery and file stats now run when the model selector is first opened.
+- Restored automatic YOLO category population on the first real mouse, key, or wheel interaction anywhere in Auto-Markings; startup show/focus events remain ignored, and Start reuses the prepared session.

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -83,3 +83,5 @@
 - Moved the settings-dependent FFmpeg acceleration helper behind decode validation too; standalone `VideoValidator` import fell from ~150–172 ms to ~40–53 ms and no longer initializes Qt settings.
 - Third-pass focused coverage reached 15 passing tests; the full suite reached 92 passed with the same nine recorded baseline failures, and the tree remained compile/whitespace clean.
 - Completed the focused 10-minute continuation after 21:03 BRT, still isolated on the optimization branch with no staging, commit, push, or system-level changes.
+- Measured the deferred Hugging Face availability pass on the current 18.63 GiB cache: roughly 440 ms to import `huggingface_hub`, 70–77 ms to scan, and 525–560 ms end to end.
+- Replaced the 1.2-second post-show availability timer with true first-use discovery when the Auto-Captioner model selector is opened, avoiding the half-second UI pause for sessions that do not inspect caption models.

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -93,3 +93,4 @@
 - Moved model preparation and the first category lookup to a single guarded worker job, cached the category snapshot, and made overlapping panel/selector/Start requests share the same in-flight load.
 - Added a persistent Auto-Markings class metadata cache keyed by resolved path, size, and modification time, allowing category UI to populate without constructing a model runtime.
 - Added a shared in-memory model runtime cache used by Auto-Markings and pipeline `MarkingThread` instances; unchanged models load once per application session and inference is serialized per shared runtime.
+- Restored the saved model entry and valid cached categories automatically after Auto-Markings construction, without scanning the model directory, loading ONNX, or waiting for panel interaction.

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -87,3 +87,4 @@
 - Replaced the 1.2-second post-show availability timer with true first-use discovery when the Auto-Captioner model selector is opened, avoiding the half-second UI pause for sessions that do not inspect caption models.
 - Traced repeated Ultralytics startup messages to the delayed Auto-Markings selection restore: it called `prepare_generation()`, created a real ONNX Runtime GPU session, and selection signals could repeat that work.
 - Removed startup model preloading, made selection changes bookkeeping-only, loaded models on explicit activation or Start, and reused an already prepared matching session.
+- Removed the remaining six-second Auto-Markings directory-scan timer; recursive model discovery and file stats now run when the model selector is first opened.

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -89,3 +89,5 @@
 - Removed startup model preloading, made selection changes bookkeeping-only, loaded models on explicit activation or Start, and reused an already prepared matching session.
 - Removed the remaining six-second Auto-Markings directory-scan timer; recursive model discovery and file stats now run when the model selector is first opened.
 - Restored automatic YOLO category population on the first real mouse, key, or wheel interaction anywhere in Auto-Markings; startup show/focus events remain ignored, and Start reuses the prepared session.
+- Traced three identical ONNX loads to three UI-side `YOLO.names` reads during category-table construction; Ultralytics can initialize the backend through that property.
+- Moved model preparation and the first category lookup to a single guarded worker job, cached the category snapshot, and made overlapping panel/selector/Start requests share the same in-flight load.

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -1,0 +1,85 @@
+# Performance Audit Diary — 2026-07-17
+
+- Extended the audit window by another 30 minutes at the user's request (18:15 BRT); continued on the same isolated branch and repository-only scope.
+- Created `codex/performance-audit-20260717` from the current local `main` state to isolate all audit work.
+- Loaded the project index and identified startup, masonry, paginated model, thumbnail cache, image viewer, and video player paths as the primary audit scope.
+- Measured the hidden main-window import phase: ~14.0 s warm, with ~11.6 s caused by eager auto-captioning imports (`torch`, `transformers`, `torchvision`, and adapters).
+- Reworked the auto-captioning registry and UI metadata checks to stay lightweight at startup and resolve concrete ML classes only when captioning begins.
+- Replaced eager `bitsandbytes` initialization with a package-presence check and removed a batch-dialog dependency on the full auto-captioner module.
+- Found two remaining eager paths through auto-marking and pipeline execution; deferred their worker imports until the user actually starts those operations.
+- Re-measured the clean-process main-window import at ~1.55 s versus ~14.0 s before (~89% faster); confirmed no ML framework or execution worker is loaded by a normal GUI import.
+- Profiled full offscreen construction: repeated spell dictionaries cost ~0.72 s across five editors, so highlighters now share one read-only dictionary per language.
+- Deferred `language_tool_python` until grammar checking is invoked; startup only needs its lightweight enums and availability flag.
+- Re-ran the isolated full-startup harness: total import + QApplication + MainWindow construction improved from ~4.45 s to ~2.30 s.
+- Added focused regression coverage for lazy dependency loading, metadata/class mapping, local WD model detection, and shared spell dictionaries.
+- Benchmarked the masonry worker at ~590–624 ms for 250K items and found per-item lambda scans plus a second dataclass-to-dict pass in the core loop.
+- Replaced the shortest/tallest-column lambdas with tie-compatible loops and emitted result dictionaries directly to reduce layout CPU and peak temporary memory.
+- Re-measured 250K-item masonry at ~256–287 ms (~54–57% faster) and added a regression test covering ties, invalid ratios, spacing, and spacer placement.
+- Audited image/video rendering and kept the existing backend timers, seek coalescing, mipmap cache, and main-viewer wiring unchanged because they are already specialized and broadly coupled.
+- Deferred construction of complex Pipeline step cards while its dock is hidden; profile data remains loaded and cards build on the first show.
+- Confirmed the hidden dock starts with zero cards and builds all six default cards when shown; isolated total startup measured ~1.72 s after this change.
+- Found auto-caption model availability was scanned three times for the same compact form; deduplicated form refreshes and deferred the initial decorative cache scan until the dock is shown.
+- Qt emits show events for every tabified dock during main-window display, so moved the decorative model-cache scan to a 1.2 s post-show timer to protect first paint.
+- Deferred `huggingface_hub` itself until the delayed cache scan, removing another optional network/cache library tree from GUI import.
+- Real adapter resolution exposed a lazy-load circular import; converted worker-only type references to `TYPE_CHECKING` imports in the base, worker, Remote, WD Tagger, and Phi adapters.
+- Removed runtime NumPy/Transformers imports used only by `ModelThread` annotations so clicking Start can construct and launch the worker without blocking the UI on framework imports.
+- Applied the same worker-thread boundary to auto-marking: Ultralytics and Torch now import inside model preload/device selection rather than during the Start-button handler.
+- Audited a saved 34K-image restore and found all three 1K-item pages were built synchronously (~2.55 s); changed bootstrap to expose page 0 immediately and warm pages 1–2 through the existing page executor.
+- Benchmarked the 1M test index: `COUNT(*)` took ~0.3 ms, while fetching all 1,000,055 paths took ~3.12 s and ~168 MiB peak Python memory.
+- Changed cached paginated startup to use the DB count and materialize paths only inside delayed background validation; non-paginated scan/freshness behavior remains unchanged.
+- Exercised the real 1,000,055-row test index: `load_directory` returned with page 0 usable in ~712 ms and pages 1–2 completed through the existing background executor.
+- Moved the unchanged-directory signature check ahead of background path loading, so stable folders skip the million-string allocation entirely; changed folders retain full reconciliation.
+- Reduced changed-folder validation memory by replacing the normalized path dict-of-lists plus copied key set with one canonical map while preserving duplicate winner/removal semantics.
+- Removed per-lookup `mkdir` calls from thumbnail cache reads; hash bucket directories are now created only on writes.
+- Microbenchmarked 20K cache-path lookups at ~54 ms without directory creation versus ~3.45 s with the former `mkdir` behavior on this Windows filesystem.
+- Replaced GUI-thread thumbnail cache probes that decoded every cached pixmap with existence-only checks, and stopped the preliminary preload scan once its 50-item decision threshold is reached.
+- Made completed thumbnail assignment O(1) when the submitted row is unchanged, retaining the path scan only as a correctness fallback after sorting/reordering.
+- Replaced worker-side future removal with post-registration completion callbacks, preventing fast cache hits from leaving stale futures and preventing old row tasks from removing newer ones.
+- Profiled a cold main-window import and found optional MPV/VLC probing loaded native DLLs even with the stable Qt backend selected; deferred those probes until an experimental backend or its settings status is requested.
+- Kept `VideoPlayer` construction runtime-light even when an experimental backend is saved; native probing now starts when a video is actually loaded, preserving the existing load/play behavior.
+- Made `utils.video` exports independent and deferred `VideoEditor` resolution until an editing command, avoiding frame/SAR/batch backend imports during callback wiring.
+- Deferred Settings, Export, Find/Replace, and Batch Reorder dialog imports until their menu commands; Settings alone previously added roughly 270 ms to clean GUI import.
+- Final clean-process main-window imports measured ~721–747 ms and loaded none of Torch, Transformers, MPV, or VLC.
+- Focused startup/masonry/pipeline/thumbnail integration suite passed 39 tests; all changed Python files compiled and the patch passed `git diff --check`.
+- Full suite result was 86 passed / 9 failed; every failure maps to an untouched baseline file (compare drag, masonry submission cadence, sidecar reconciliation, or strict scroll-domain expectations).
+- Audited entry-point media-runtime and Pillow codec bootstraps; kept the cheap idempotent runtime-path discovery and codec registration because they establish DLL/decoder availability before saved-folder restoration.
+- Measured the real `run_gui` import boundary at ~702–761 ms across clean processes, again with no ML framework or optional MPV/VLC Python runtime loaded.
+- Revalidated real lazy adapter resolution after the final import changes: Remote, WD Tagger, Qwen VL, Florence PromptGen, and XComposer all resolved to their expected concrete classes.
+- Confirmed both deferred experimental playback probes still resolve successfully on demand (MPV and VLC), while player construction keeps them unloaded.
+- Considered moving the Hugging Face cache scan fully off-thread, but left it as a delayed UI task because its current helpers and combo-box updates share mutable Qt/cache state; that deserves a separately tested worker/result boundary rather than a late unsafe change.
+- Restored the original XComposer UI availability gate with `find_spec('gptqmodel')`; explicit saved IDs remain resolvable, but unavailable choices are no longer newly exposed.
+- The repository's ignored `test-1m-images` index was opened by the current app and migrated from DB v9 to v11 during benchmarking; no media files or system files were deleted or modified.
+- Completed the user-extended audit window after 18:45 BRT with the branch isolated, patch whitespace-clean, and no staging, commit, push, or system-level changes.
+- Started a second 30-minute audit pass at 20:21 BRT on the same isolated branch and repository-only scope.
+- Profiled unshown `MainWindow` construction at ~546–609 ms without profiler overhead; eager video-skin catalog parsing remained a repeatable ~70–98 ms cost.
+- Changed startup video controls to parse only the selected skin; the complete YAML catalog still refreshes when the skin menu is opened.
+- Deferred creation of the shared spell dictionary until non-empty text is highlighted or queried; empty descriptive editors no longer pay its ~100–140 ms startup cost.
+- Kept saved prompt text unhighlighted until its editor receives focus, so constructing the hidden auto-caption form does not immediately force the shared spell dictionary to load.
+- Reused the existing spawned-viewer `video_components_ready` wiring for the main viewer; player, controls, overlays, and QMedia objects now construct on the first video instead of every image-only startup.
+- Exercised the lazy main viewer with a generated temporary MP4: first-video creation emitted/wired controls correctly and the clip loaded through the existing MPV fallback path.
+- Re-measured the combined unshown constructor at ~289–350 ms; the spell dictionary stayed unloaded and the player/controls remained absent.
+- Deferred the `video_player` and `video_controls` module imports themselves, so an image-only startup no longer imports Qt Multimedia, video backends, skin YAML, or their widget classes.
+- Deferred the comparison-window module until an A/B comparison is requested; its shared video controls no longer pull the skin stack into normal startup.
+- Found OpenCV imported globally by `ImageListModel` for rare fallback/video paths; moving it to those call sites reduced fresh `MainWindow` import from ~513–680 ms to ~365–384 ms after warm-up.
+- Deferred `exifread` and `imagesize` until directory metadata work begins; their isolated import cost was ~80 ms and ~20 ms respectively, and the work still occurs inside existing load/enrichment paths.
+- Deferred the multiprocessing process-pool stack until changed-subtree scanning creates its executor; normal startup and basic image use only retain the existing thread pools.
+- Deferred prompt-history and multi-image confirmation dialog modules until their corresponding caption/marking commands.
+- Deferred fullscreen-host and secondary-browser modules until those features are opened; saved secondary-browser restoration still creates it through the same on-demand method.
+- Stopped masonry cache misses from creating the cache directory; the directory is now created only before an asynchronous cache write.
+- Verified the deferred metadata modules and subtree `ProcessPoolExecutor` still resolve correctly on their first real request.
+- Final clean-process import + `QApplication` + unshown `MainWindow` measurements were ~801–866 ms after warm-up (one colder run ~929 ms), versus ~2.30 s at the comparable first-pass checkpoint.
+- After the final command-only module deferrals and filesystem warm-up, three additional import + constructor runs measured ~699–781 ms (plus ~8 ms for `QApplication`) with all audited heavy modules still absent.
+- Profiled the remaining hidden Auto-Captioner cost (~69–75 ms); roughly 44 ms is Qt parsing its compact stylesheet, which I kept synchronous to avoid a visible unstyled flash and layout-mode race.
+- Cached the full skin-catalog parse behind a cheap file signature: the first submenu discovery remained ~75 ms, while unchanged repeat opens dropped to ~0.6–0.7 ms and changed files still invalidate by path/mtime/size.
+- Re-ran the 250K-item masonry benchmark at ~260–301 ms with identical item count and total height.
+- Focused second-pass regression coverage passed 14 tests; the full suite reached 91 passed with the same nine unrelated baseline failures recorded in the first pass.
+- Completed the second 30-minute audit window after 20:51 BRT with all work isolated on the optimization branch and no staging, commit, push, or system-level changes.
+- Started a third focused 10-minute pass after 20:53 BRT on the same isolated branch.
+- Found `VideoPlayerWidget` still imported OpenCV through both a global import and an unused `VideoValidator` import; moved OpenCV behind the existing exact-frame/capture fallback.
+- Re-measured player module import at ~87–113 ms versus ~168–177 ms before, while construction remained ~96–106 ms and OpenCV stayed absent.
+- In a fully constructed main window, first video-component creation now measured ~212–217 ms with OpenCV absent; before this refinement the deferred imports plus controls/player path was roughly ~300+ ms.
+- Exercised a generated temporary MP4 with cached metadata/preview: fast load succeeded without OpenCV, then exact-frame extraction loaded OpenCV on demand and returned the expected 48×64 RGB frame.
+- Deferred OpenCV inside `VideoValidator` as well; normal ffprobe validation no longer pays the frame-sampling dependency unless deep validation is requested.
+- Moved the settings-dependent FFmpeg acceleration helper behind decode validation too; standalone `VideoValidator` import fell from ~150–172 ms to ~40–53 ms and no longer initializes Qt settings.
+- Third-pass focused coverage reached 15 passing tests; the full suite reached 92 passed with the same nine recorded baseline failures, and the tree remained compile/whitespace clean.
+- Completed the focused 10-minute continuation after 21:03 BRT, still isolated on the optimization branch with no staging, commit, push, or system-level changes.

--- a/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
+++ b/docs/PERFORMANCE_AUDIT_DIARY_2026-07-17.md
@@ -85,3 +85,5 @@
 - Completed the focused 10-minute continuation after 21:03 BRT, still isolated on the optimization branch with no staging, commit, push, or system-level changes.
 - Measured the deferred Hugging Face availability pass on the current 18.63 GiB cache: roughly 440 ms to import `huggingface_hub`, 70–77 ms to scan, and 525–560 ms end to end.
 - Replaced the 1.2-second post-show availability timer with true first-use discovery when the Auto-Captioner model selector is opened, avoiding the half-second UI pause for sessions that do not inspect caption models.
+- Traced repeated Ultralytics startup messages to the delayed Auto-Markings selection restore: it called `prepare_generation()`, created a real ONNX Runtime GPU session, and selection signals could repeat that work.
+- Removed startup model preloading, made selection changes bookkeeping-only, loaded models on explicit activation or Start, and reused an already prepared matching session.

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -56,7 +56,10 @@ saved selection. A session is created when the user explicitly activates a
 model, starts marking, or first interacts with the Auto-Markings panel. This
 preserves automatic category population for an already-open panel without
 mistaking Qt startup show events for user intent. A matching prepared session is
-reused by Start.
+reused by Start. Model construction and the first Ultralytics category lookup
+run on a dedicated worker; the UI receives one cached category snapshot. This
+avoids both GUI blocking and repeated ONNX backend initialization through
+multiple `YOLO.names` property reads.
 
 The main image viewer creates its video player, controls, overlays, and media
 objects on the first video. A first video can therefore have a small one-time

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -66,7 +66,9 @@ Successful model inspection stores only the small class-ID/name mapping under
 file size, and modification time, so changing the model invalidates its
 metadata automatically. An unchanged entry lets Auto-Markings and the Pipeline
 Editor display categories without opening ONNX Runtime or allocating GPU
-memory.
+memory. The saved Auto-Markings model and its categories restore immediately
+from this metadata without scanning the complete model directory or requiring
+panel interaction.
 
 Actual model runtimes use a separate in-memory cache with the same file
 signature. Auto-Markings and pipeline threads share the runtime and serialize

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -91,9 +91,9 @@ both very fast cache hits and replacement tasks.
 - The first use of a deferred feature pays its import or construction cost.
 - The first video remains limited by backend initialization, media probing,
   decoder startup, keyframe placement, and file/device throughput.
-- The delayed Hugging Face cache scan remains on the UI thread because its
-  helpers and combo-box updates share mutable state. Moving it requires a
-  separately designed worker/result boundary.
+- Hugging Face cache discovery runs when the Auto-Captioner model selector is
+  first opened, rather than during startup. It remains on the UI thread because
+  its helpers and combo-box updates share mutable state.
 - The compact Auto-Captioner stylesheet remains synchronous to avoid an
   unstyled flash and layout-mode race.
 - Entry-point media-runtime discovery and Pillow codec registration remain eager
@@ -125,8 +125,4 @@ against the target branch before treating them as regressions.
 ## Further Optimization
 
 Broad startup optimization now has diminishing returns. Future work should be
-profile-driven and preferably isolated by subsystem. The most promising separate
-projects are asynchronous Hugging Face cache discovery and instrumentation of
-time from a video click to the first presented frame. The latter should split
-component construction, backend probing, media loading, decoder readiness, and
-first-frame presentation before changing playback behavior.
+profile-driven and preferably isolated by subsystem.

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -50,6 +50,11 @@ Model lists and availability metadata remain lightweight. Concrete model classes
 resolve when captioning starts. Type-only worker references use
 `TYPE_CHECKING`, preventing the lazy boundary from recreating circular imports.
 
+Auto-Markings still discovers model filenames after startup, but it does not
+construct an Ultralytics or ONNX Runtime session while restoring the saved
+selection. A session is created when the user explicitly activates a model or
+starts marking, and a matching prepared session is reused by Start.
+
 The main image viewer creates its video player, controls, overlays, and media
 objects on the first video. A first video can therefore have a small one-time
 construction cost. Subsequent video switches reuse those components; decoding a

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -1,0 +1,132 @@
+# Performance Architecture and Verification
+
+This document describes the performance work introduced after TagGUI Video 1M
+1.4.2. It records the intended architectural boundaries, the measurements that
+motivated them, and the checks needed before release. The chronological
+[audit diary](PERFORMANCE_AUDIT_DIARY_2026-07-17.md) contains the full
+investigation log.
+
+## Goals
+
+- Show the usable GUI without initializing features the user has not requested.
+- Keep image-only workflows independent of video and machine-learning runtimes.
+- Make cached large folders useful before full background validation completes.
+- Reduce CPU, allocation, and filesystem work in masonry and thumbnail hot paths.
+- Preserve existing behavior by moving work to established feature boundaries
+  rather than removing it.
+
+## Measured Results
+
+Measurements were taken on the audit machine with the same working tree and
+represent development benchmarks rather than release guarantees.
+
+| Scenario | Earlier measurement | Optimized measurement |
+| --- | ---: | ---: |
+| Clean `main_window` import | about 14.0 s | about 0.72–0.75 s |
+| Import + application + unshown main window | about 4.45 s | about 0.70–0.87 s warm |
+| Masonry layout, 250,000 items | about 590–624 ms | about 256–301 ms |
+| Thumbnail cache paths, 20,000 reads | about 3.45 s | about 54 ms |
+| Reopening an unchanged skin catalog | about 75 ms | about 0.6–0.7 ms |
+| First deferred video-component construction | roughly 300+ ms | about 212–217 ms |
+
+The 1,000,055-row indexed-folder test returned from `load_directory` with page
+zero usable in about 712 ms while later pages warmed through the existing
+executor. Fetching every path up front had taken about 3.12 seconds and about
+168 MiB of peak Python memory.
+
+## Startup Boundaries
+
+Normal startup now keeps these feature families behind their first real use:
+
+- Torch, Transformers, Ultralytics, caption-model adapters, and execution workers
+- MPV and VLC probing, Qt Multimedia widgets, skin catalogs, and video editing
+- OpenCV exact-frame fallbacks and deep video validation
+- Settings, Export, Find/Replace, Batch Reorder, history, and confirmation dialogs
+- comparison, fullscreen, and secondary-browser windows
+- EXIF and image-size enrichment, changed-subtree process pools, grammar tools,
+  and spell dictionaries
+
+Model lists and availability metadata remain lightweight. Concrete model classes
+resolve when captioning starts. Type-only worker references use
+`TYPE_CHECKING`, preventing the lazy boundary from recreating circular imports.
+
+The main image viewer creates its video player, controls, overlays, and media
+objects on the first video. A first video can therefore have a small one-time
+construction cost. Subsequent video switches reuse those components; decoding a
+high-resolution video can still take longer than displaying its already-decoded
+thumbnail or an image.
+
+## Large Folders
+
+For a valid paginated index:
+
+1. The database count establishes the model size without loading every path.
+2. Page zero becomes available synchronously.
+3. The next pages warm through the existing page executor.
+4. Delayed validation first compares the directory signature.
+5. Only a changed directory performs full path reconciliation.
+
+Fresh scans and non-paginated behavior are unchanged. Changed-folder validation
+still preserves duplicate winner/removal behavior while using a single canonical
+path map to reduce temporary memory.
+
+## Masonry and Thumbnails
+
+The masonry worker replaces repeated lambda scans and a second result-conversion
+pass with tie-compatible loops that emit the final dictionaries directly.
+Invalid aspect-ratio, spacing, ordering, and spacer semantics remain covered.
+
+Thumbnail reads no longer create hash-bucket directories; writes create them as
+needed. GUI probes test cache-file existence without decoding every pixmap, and
+the preliminary preload scan stops once its decision threshold is known.
+Completed tasks normally assign by the unchanged submitted row in constant time,
+with a path search retained after sorting or reordering.
+
+Completion callbacks are registered only after the future is stored. A callback
+removes a future only if it is still the current future for that row, protecting
+both very fast cache hits and replacement tasks.
+
+## Intentional Tradeoffs
+
+- The first use of a deferred feature pays its import or construction cost.
+- The first video remains limited by backend initialization, media probing,
+  decoder startup, keyframe placement, and file/device throughput.
+- The delayed Hugging Face cache scan remains on the UI thread because its
+  helpers and combo-box updates share mutable state. Moving it requires a
+  separately designed worker/result boundary.
+- The compact Auto-Captioner stylesheet remains synchronous to avoid an
+  unstyled flash and layout-mode race.
+- Entry-point media-runtime discovery and Pillow codec registration remain eager
+  because saved-folder restoration may need their DLLs and decoders immediately.
+
+## Release Verification
+
+Before merging, manually verify:
+
+- cold start with no restored folder;
+- restore a small image folder and a large indexed folder;
+- scroll while thumbnails are loading, then sort/filter during thumbnail work;
+- open the masonry view and resize or change its column count;
+- open the first video, play/pause/seek, then switch repeatedly between videos;
+- repeat the video test with the configured Qt, MPV, and VLC backends that are
+  supported by the release environment;
+- run one local caption model, one remote caption model, auto-marking, and a
+  pipeline;
+- open Settings, Export, Find/Replace, Batch Reorder, Compare, fullscreen, and
+  the secondary browser;
+- enable spell and grammar checks and confirm model availability indicators;
+- reopen the video-skin menu, then edit a skin and confirm cache invalidation.
+
+The final audit suite reached 92 passing tests with nine failures also present in
+untouched baseline areas: compare dragging, masonry submission cadence, sidecar
+reconciliation, and strict scroll-domain expectations. Compare these failures
+against the target branch before treating them as regressions.
+
+## Further Optimization
+
+Broad startup optimization now has diminishing returns. Future work should be
+profile-driven and preferably isolated by subsystem. The most promising separate
+projects are asynchronous Hugging Face cache discovery and instrumentation of
+time from a video click to the first presented frame. The latter should split
+component construction, backend probing, media loading, decoder readiness, and
+first-frame presentation before changing playback behavior.

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -61,6 +61,21 @@ run on a dedicated worker; the UI receives one cached category snapshot. This
 avoids both GUI blocking and repeated ONNX backend initialization through
 multiple `YOLO.names` property reads.
 
+Successful model inspection stores only the small class-ID/name mapping under
+`.taggui_cache/marking_models`. The entry is keyed by the resolved model path,
+file size, and modification time, so changing the model invalidates its
+metadata automatically. An unchanged entry lets Auto-Markings and the Pipeline
+Editor display categories without opening ONNX Runtime or allocating GPU
+memory.
+
+Actual model runtimes use a separate in-memory cache with the same file
+signature. Auto-Markings and pipeline threads share the runtime and serialize
+inference through a per-model lock. Consequently, the first run after launching
+the application still pays the unavoidable model-loading cost, while subsequent
+pipeline runs using the same unchanged models reuse their sessions. Runtime
+entries intentionally live until application exit; persistent storage contains
+metadata only, never executable model objects.
+
 The main image viewer creates its video player, controls, overlays, and media
 objects on the first video. A first video can therefore have a small one-time
 construction cost. Subsequent video switches reuse those components; decoding a
@@ -100,6 +115,8 @@ both very fast cache hits and replacement tasks.
 ## Intentional Tradeoffs
 
 - The first use of a deferred feature pays its import or construction cost.
+- Every distinct Auto-Markings model used in a session may retain its runtime
+  and associated CPU/GPU memory until the application exits.
 - The first video remains limited by backend initialization, media probing,
   decoder startup, keyframe placement, and file/device throughput.
 - Hugging Face cache discovery runs when the Auto-Captioner model selector is

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -53,7 +53,10 @@ resolve when captioning starts. Type-only worker references use
 Auto-Markings discovers model filenames when its selector is first opened and
 does not construct an Ultralytics or ONNX Runtime session while restoring the
 saved selection. A session is created when the user explicitly activates a
-model or starts marking, and a matching prepared session is reused by Start.
+model, starts marking, or first interacts with the Auto-Markings panel. This
+preserves automatic category population for an already-open panel without
+mistaking Qt startup show events for user intent. A matching prepared session is
+reused by Start.
 
 The main image viewer creates its video player, controls, overlays, and media
 objects on the first video. A first video can therefore have a small one-time

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -50,10 +50,10 @@ Model lists and availability metadata remain lightweight. Concrete model classes
 resolve when captioning starts. Type-only worker references use
 `TYPE_CHECKING`, preventing the lazy boundary from recreating circular imports.
 
-Auto-Markings still discovers model filenames after startup, but it does not
-construct an Ultralytics or ONNX Runtime session while restoring the saved
-selection. A session is created when the user explicitly activates a model or
-starts marking, and a matching prepared session is reused by Start.
+Auto-Markings discovers model filenames when its selector is first opened and
+does not construct an Ultralytics or ONNX Runtime session while restoring the
+saved selection. A session is created when the user explicitly activates a
+model or starts marking, and a matching prepared session is reused by Start.
 
 The main image viewer creates its video player, controls, overlays, and media
 objects on the first video. A first video can therefore have a small one-time

--- a/taggui/auto_captioning/auto_captioning_model.py
+++ b/taggui/auto_captioning/auto_captioning_model.py
@@ -9,6 +9,7 @@ from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
 from time import perf_counter, sleep
+from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
@@ -23,7 +24,6 @@ except ImportError:
     from transformers import AutoModelForVision2Seq
 from transformers.utils.import_utils import is_torch_bf16_gpu_available
 
-import auto_captioning.captioning_thread as captioning_thread
 from auto_captioning.model_availability import (
     MODEL_ARTIFACT_KIND_HUGGINGFACE,
     MODEL_ARTIFACT_KIND_WD_TAGGER,
@@ -34,6 +34,9 @@ from auto_captioning.model_availability import (
 from models.image_list_model import _video_lock
 from utils.enums import CaptionDevice
 from utils.image import Image
+
+if TYPE_CHECKING:
+    import auto_captioning.captioning_thread as captioning_thread
 
 
 class CaptionGenerationError(RuntimeError):

--- a/taggui/auto_captioning/captioning_thread.py
+++ b/taggui/auto_captioning/captioning_thread.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QModelIndex, Signal
 
-from auto_captioning.auto_captioning_model import AutoCaptioningModel
 from auto_captioning.models_list import get_model_class
 from models.image_list_model import ImageListModel
 from utils.enums import CaptionPosition
@@ -16,6 +18,9 @@ from utils.ideogram_caption import (
     preserve_seed_bboxes,
     save_ideogram_caption,
 )
+
+if TYPE_CHECKING:
+    from auto_captioning.auto_captioning_model import AutoCaptioningModel
 
 
 def add_caption_to_tags(tags: list[str], caption: str,

--- a/taggui/auto_captioning/model_availability.py
+++ b/taggui/auto_captioning/model_availability.py
@@ -4,10 +4,6 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from huggingface_hub import scan_cache_dir
-from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
-from huggingface_hub.errors import CacheNotFound
-
 MODEL_ARTIFACT_KIND_HUGGINGFACE = 'huggingface'
 MODEL_ARTIFACT_KIND_REMOTE = 'remote'
 MODEL_ARTIFACT_KIND_WD_TAGGER = 'wd_tagger'
@@ -219,6 +215,13 @@ def _get_cached_snapshot_paths(repo_id: str,
 
 
 def _get_hf_cache_index() -> dict[str, list[dict]]:
+    try:
+        from huggingface_hub import scan_cache_dir
+        from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+        from huggingface_hub.errors import CacheNotFound
+    except ImportError:
+        return {}
+
     cache_root = str(Path(HUGGINGFACE_HUB_CACHE))
     cached_index = _CACHE_INDEX.get(cache_root)
     if cached_index is not None:

--- a/taggui/auto_captioning/models/phi_3_vision.py
+++ b/taggui/auto_captioning/models/phi_3_vision.py
@@ -1,9 +1,13 @@
+from typing import TYPE_CHECKING
+
 import torch
 from transformers import AutoModelForCausalLM, BatchFeature
 
-import auto_captioning.captioning_thread as captioning_thread
 from auto_captioning.auto_captioning_model import AutoCaptioningModel
 from utils.image import Image
+
+if TYPE_CHECKING:
+    import auto_captioning.captioning_thread as captioning_thread
 
 
 class Phi3Vision(AutoCaptioningModel):

--- a/taggui/auto_captioning/models/remote.py
+++ b/taggui/auto_captioning/models/remote.py
@@ -5,6 +5,7 @@ import math
 import re
 from itertools import cycle
 from time import perf_counter
+from typing import TYPE_CHECKING
 
 import cv2
 import requests
@@ -15,7 +16,8 @@ from auto_captioning.model_availability import MODEL_ARTIFACT_KIND_REMOTE
 from models.image_list_model import _video_lock
 from utils.ideogram_caption import ideogram_caption_response_format
 from utils.image import Image
-import auto_captioning.captioning_thread as captioning_thread
+if TYPE_CHECKING:
+    import auto_captioning.captioning_thread as captioning_thread
 
 
 class RemoteGen(AutoCaptioningModel):

--- a/taggui/auto_captioning/models/wd_tagger.py
+++ b/taggui/auto_captioning/models/wd_tagger.py
@@ -4,6 +4,7 @@ import csv
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import huggingface_hub
 import numpy as np
@@ -15,10 +16,12 @@ except Exception as exc:
     InferenceSession = None
     _ONNXRUNTIME_IMPORT_ERROR = exc
 
-import auto_captioning.captioning_thread as captioning_thread
 from auto_captioning.auto_captioning_model import AutoCaptioningModel
 from auto_captioning.model_availability import MODEL_ARTIFACT_KIND_WD_TAGGER
 from utils.image import Image
+
+if TYPE_CHECKING:
+    import auto_captioning.captioning_thread as captioning_thread
 
 KAOMOJIS = ['0_0', '(o)_(o)', '+_+', '+_-', '._.', '<o>_<o>', '<|>_<|>', '=_=',
             '>_<', '3_3', '6_9', '>_o', '@_@', '^_^', 'o_o', 'u_u', 'x_x',

--- a/taggui/auto_captioning/models_list.py
+++ b/taggui/auto_captioning/models_list.py
@@ -1,29 +1,26 @@
-from auto_captioning.auto_captioning_model import AutoCaptioningModel
-from auto_captioning.models.cogvlm import Cogvlm
-from auto_captioning.models.cogvlm2 import Cogvlm2
-from auto_captioning.models.florence_2 import Florence2, Florence2Promptgen
-from auto_captioning.models.gemma_4 import Gemma4
-from auto_captioning.models.joycaption import Joycaption
-from auto_captioning.models.kosmos_2 import Kosmos2
-from auto_captioning.models.llava_1_point_5 import Llava1Point5
-from auto_captioning.models.llava_llama_3 import LlavaLlama3
-from auto_captioning.models.llava_next import (LlavaNext34b, LlavaNextMistral,
-                                               LlavaNextVicuna)
-from auto_captioning.models.moondream import Moondream1, Moondream2
-from auto_captioning.models.phi_3_vision import Phi3Vision
-from auto_captioning.models.wd_tagger import WdTagger
-from auto_captioning.models.remote import RemoteGen
-try:
-    from auto_captioning.models.qwen_vl import QwenVL
-    has_qwen_vl = True
-except Exception:
-    has_qwen_vl = False
-try:
-    from auto_captioning.models.xcomposer2 import Xcomposer2, Xcomposer2_4khd
-    hasgptqmodel = True
-except:
-    hasgptqmodel = False
-    print("GPTQModel failed to install")
+"""Lightweight auto-captioning model registry.
+
+Keep model metadata importable by the GUI without importing torch,
+transformers, torchvision, or every model adapter during application startup.
+Concrete model classes are resolved only when captioning actually starts.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib import import_module
+from importlib.util import find_spec
+from pathlib import Path
+
+from auto_captioning.model_availability import (
+    MODEL_ARTIFACT_KIND_HUGGINGFACE,
+    MODEL_ARTIFACT_KIND_REMOTE,
+    MODEL_ARTIFACT_KIND_WD_TAGGER,
+)
+
+MODEL_KIND_LOCAL = 'local'
+MODEL_KIND_REMOTE = 'remote'
+MODEL_KIND_WD_TAGGER = 'wd_tagger'
 
 MODELS = [
     # Qwen VL — native video + image captioning (requires qwen-vl-utils)
@@ -31,7 +28,7 @@ MODELS = [
     'Qwen/Qwen2.5-VL-7B-Instruct',
     'Qwen/Qwen3.5-4B',
     'Qwen/Qwen3.5-9B',
-    'huihui-ai/Huihui-Qwen3.5-9B-abliterated',  # uncensored abliterated variant
+    'huihui-ai/Huihui-Qwen3.5-9B-abliterated',
     'google/gemma-4-E2B-it',
     'google/gemma-4-E4B-it',
     'google/gemma-4-26B-A4B-it',
@@ -77,58 +74,105 @@ MODELS = [
     'Salesforce/blip2-flan-t5-xl',
     'Salesforce/blip2-flan-t5-xxl',
     'microsoft/kosmos-2-patch14-224',
-    'Remote'
+    'Remote',
 ]
-if hasgptqmodel:
-    MODELS.extend(
-    ['internlm/internlm-xcomposer2-vl-7b-4bit',
-    'internlm/internlm-xcomposer2-vl-7b',
-    'internlm/internlm-xcomposer2-vl-1_8b',
-    'internlm/internlm-xcomposer2-4khd-7b']
-    )
 
-def get_model_class(model_id: str) -> type[AutoCaptioningModel]:
-    lowercase_model_id = model_id.lower()
-    if has_qwen_vl:
-        if 'qwen2.5-vl' in lowercase_model_id or 'qwen3.5' in lowercase_model_id:
-            return QwenVL
-    if 'gemma-4' in lowercase_model_id:
-        return Gemma4
-    if 'cogvlm2' in lowercase_model_id:
-        return Cogvlm2
-    if 'cogvlm' in lowercase_model_id:
-        return Cogvlm
-    if 'florence' in lowercase_model_id:
-        if 'promptgen' in lowercase_model_id:
-            return Florence2Promptgen
-        return Florence2
-    if 'joycaption' in lowercase_model_id:
-        return Joycaption
-    if 'kosmos' in lowercase_model_id:
-        return Kosmos2
-    if 'llava-v1.6-34b' in lowercase_model_id:
-        return LlavaNext34b
-    if 'llava-v1.6-mistral' in lowercase_model_id:
-        return LlavaNextMistral
-    if 'llava-v1.6-vicuna' in lowercase_model_id:
-        return LlavaNextVicuna
-    if 'llava-llama-3' in lowercase_model_id:
-        return LlavaLlama3
-    if 'llava' in lowercase_model_id:
-        return Llava1Point5
-    if 'moondream1' in lowercase_model_id:
-        return Moondream1
-    if 'moondream2' in lowercase_model_id:
-        return Moondream2
-    if 'phi-3' in lowercase_model_id:
-        return Phi3Vision
+if find_spec('gptqmodel') is not None:
+    MODELS.extend([
+        'internlm/internlm-xcomposer2-vl-7b-4bit',
+        'internlm/internlm-xcomposer2-vl-7b',
+        'internlm/internlm-xcomposer2-vl-1_8b',
+        'internlm/internlm-xcomposer2-4khd-7b',
+    ])
+
+
+def get_model_kind(model_id: str) -> str:
+    """Classify a model without importing its implementation."""
+    model_id_text = str(model_id or '').strip()
+    model_path = Path(model_id_text).expanduser()
+    if (
+        model_path.is_dir()
+        and (model_path / 'model.onnx').is_file()
+        and (model_path / 'selected_tags.csv').is_file()
+    ):
+        return MODEL_KIND_WD_TAGGER
+
+    lowercase_model_id = model_id_text.lower()
     if 'wd' in lowercase_model_id and 'tagger' in lowercase_model_id:
-        return WdTagger
-    if hasgptqmodel:
-        if 'xcomposer2' in lowercase_model_id:
-            if '4khd' in lowercase_model_id:
-                return Xcomposer2_4khd
-            return Xcomposer2
+        return MODEL_KIND_WD_TAGGER
     if 'remote' in lowercase_model_id:
-        return RemoteGen
-    return AutoCaptioningModel
+        return MODEL_KIND_REMOTE
+    return MODEL_KIND_LOCAL
+
+
+def get_model_artifact_kind(model_id: str) -> str:
+    model_kind = get_model_kind(model_id)
+    if model_kind == MODEL_KIND_WD_TAGGER:
+        return MODEL_ARTIFACT_KIND_WD_TAGGER
+    if model_kind == MODEL_KIND_REMOTE:
+        return MODEL_ARTIFACT_KIND_REMOTE
+    return MODEL_ARTIFACT_KIND_HUGGINGFACE
+
+
+def get_model_download_revision(model_id: str) -> str | None:
+    """Return download-only metadata without importing the model adapter."""
+    if 'moondream2' in str(model_id or '').lower():
+        return '2024-08-26'
+    return None
+
+
+def _load_model_class(module_name: str, class_name: str):
+    return getattr(import_module(module_name), class_name)
+
+
+@lru_cache(maxsize=None)
+def get_model_class(model_id: str):
+    """Resolve a concrete model class on first use."""
+    lowercase_model_id = str(model_id or '').lower()
+
+    module_name = 'auto_captioning.auto_captioning_model'
+    class_name = 'AutoCaptioningModel'
+    if 'qwen2.5-vl' in lowercase_model_id or 'qwen3.5' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.qwen_vl', 'QwenVL'
+    elif 'gemma-4' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.gemma_4', 'Gemma4'
+    elif 'cogvlm2' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.cogvlm2', 'Cogvlm2'
+    elif 'cogvlm' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.cogvlm', 'Cogvlm'
+    elif 'florence' in lowercase_model_id:
+        module_name = 'auto_captioning.models.florence_2'
+        class_name = (
+            'Florence2Promptgen'
+            if 'promptgen' in lowercase_model_id
+            else 'Florence2'
+        )
+    elif 'joycaption' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.joycaption', 'Joycaption'
+    elif 'kosmos' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.kosmos_2', 'Kosmos2'
+    elif 'llava-v1.6-34b' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.llava_next', 'LlavaNext34b'
+    elif 'llava-v1.6-mistral' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.llava_next', 'LlavaNextMistral'
+    elif 'llava-v1.6-vicuna' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.llava_next', 'LlavaNextVicuna'
+    elif 'llava-llama-3' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.llava_llama_3', 'LlavaLlama3'
+    elif 'llava' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.llava_1_point_5', 'Llava1Point5'
+    elif 'moondream1' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.moondream', 'Moondream1'
+    elif 'moondream2' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.moondream', 'Moondream2'
+    elif 'phi-3' in lowercase_model_id:
+        module_name, class_name = 'auto_captioning.models.phi_3_vision', 'Phi3Vision'
+    elif get_model_kind(model_id) == MODEL_KIND_WD_TAGGER:
+        module_name, class_name = 'auto_captioning.models.wd_tagger', 'WdTagger'
+    elif 'xcomposer2' in lowercase_model_id:
+        module_name = 'auto_captioning.models.xcomposer2'
+        class_name = 'Xcomposer2_4khd' if '4khd' in lowercase_model_id else 'Xcomposer2'
+    elif get_model_kind(model_id) == MODEL_KIND_REMOTE:
+        module_name, class_name = 'auto_captioning.models.remote', 'RemoteGen'
+
+    return _load_model_class(module_name, class_name)

--- a/taggui/auto_marking/marking_thread.py
+++ b/taggui/auto_marking/marking_thread.py
@@ -6,15 +6,13 @@ from PIL import Image as PILImage
 import pillow_jxl
 
 from pathlib import Path
+import threading
 from typing import TYPE_CHECKING
 
 from models.image_list_model import ImageListModel
 from utils.image import Image
 from utils.ModelThread import ModelThread
-from utils.marking_model_security import (
-    configure_ultralytics_marking_runtime,
-    infer_marking_model_task,
-)
+from auto_marking.model_cache import load_marking_runtime
 
 if TYPE_CHECKING:
     from ultralytics import YOLO
@@ -34,6 +32,7 @@ class MarkingThread(ModelThread):
         self.marking_settings = marking_settings
         self.model: YOLO | None = None
         self.model_names: dict[int, str] = {}
+        self.runtime = None
         self.model_path = marking_settings.get('model_path')
         self.text = {
             'Generating': 'Marking',
@@ -165,26 +164,16 @@ class MarkingThread(ModelThread):
             }
 
     def preload_model(self):
-        from ultralytics import YOLO
-
         self.model_path = self.marking_settings.get('model_path')
         if self.model_path is None:
             self.error_message = 'Model path not set'
             self.is_error = True
             self.model = None
             return
-        configure_ultralytics_marking_runtime(self.model_path)
-        self.model = YOLO(
-            self.model_path,
-            task=infer_marking_model_task(self.model_path),
-        )
-        # Accessing ``YOLO.names`` can initialize an ONNX backend. Capture it
-        # once on the preparation worker instead of repeatedly from the UI.
-        self.model_names = {
-            int(class_id): str(class_name)
-            for class_id, class_name in self.model.names.items()
-        }
-        self.device = self._preferred_device_for_model(self.model_path)
+        self.runtime = load_marking_runtime(self.model_path)
+        self.model = self.runtime.model
+        self.model_names = dict(self.runtime.model_names)
+        self.device = self.runtime.device
 
     @staticmethod
     def _preferred_device_for_model(model_path: str) -> str:
@@ -202,13 +191,21 @@ class MarkingThread(ModelThread):
         return 'cuda' if 'CUDAExecutionProvider' in providers else 'cpu'
 
     def _predict_with_device(self, pil_image, device: str):
-        return self.model.predict(source=pil_image,
-                                  conf=self.marking_settings['conf'],
-                                  iou=self.marking_settings['iou'],
-                                  max_det=self.marking_settings['max_det'],
-                                  classes=list(self.marking_settings['classes'].keys()),
-                                  retina_masks=True,
-                                  device=device)
+        lock = (
+            self.runtime.inference_lock
+            if self.runtime is not None
+            else threading.RLock()
+        )
+        with lock:
+            return self.model.predict(
+                source=pil_image,
+                conf=self.marking_settings['conf'],
+                iou=self.marking_settings['iou'],
+                max_det=self.marking_settings['max_det'],
+                classes=list(self.marking_settings['classes'].keys()),
+                retina_masks=True,
+                device=device,
+            )
 
     def get_model_inputs(self, image: Image):
         return '', {}

--- a/taggui/auto_marking/marking_thread.py
+++ b/taggui/auto_marking/marking_thread.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 from PySide6.QtCore import QModelIndex, QThread, Signal, Qt
 
 from PIL import Image as PILImage
 import pillow_jxl
 
-import torch
-from ultralytics import YOLO
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from models.image_list_model import ImageListModel
 from utils.image import Image
@@ -14,6 +15,9 @@ from utils.marking_model_security import (
     configure_ultralytics_marking_runtime,
     infer_marking_model_task,
 )
+
+if TYPE_CHECKING:
+    from ultralytics import YOLO
 
 
 class MarkingThread(ModelThread):
@@ -160,6 +164,8 @@ class MarkingThread(ModelThread):
             }
 
     def preload_model(self):
+        from ultralytics import YOLO
+
         self.model_path = self.marking_settings.get('model_path')
         if self.model_path is None:
             self.error_message = 'Model path not set'
@@ -175,6 +181,8 @@ class MarkingThread(ModelThread):
 
     @staticmethod
     def _preferred_device_for_model(model_path: str) -> str:
+        import torch
+
         if not torch.cuda.is_available():
             return 'cpu'
         if Path(str(model_path)).suffix.lower() != '.onnx':

--- a/taggui/auto_marking/marking_thread.py
+++ b/taggui/auto_marking/marking_thread.py
@@ -33,6 +33,7 @@ class MarkingThread(ModelThread):
         super().__init__(parent, image_list_model, selected_image_indices)
         self.marking_settings = marking_settings
         self.model: YOLO | None = None
+        self.model_names: dict[int, str] = {}
         self.model_path = marking_settings.get('model_path')
         self.text = {
             'Generating': 'Marking',
@@ -158,7 +159,7 @@ class MarkingThread(ModelThread):
                     ),
                     marking_type,
                 )
-                for class_id, class_name in self.model.names.items()
+                for class_id, class_name in self.model_names.items()
                 if not requested_names
                 or str(class_name).strip().casefold() in requested_names
             }
@@ -177,6 +178,12 @@ class MarkingThread(ModelThread):
             self.model_path,
             task=infer_marking_model_task(self.model_path),
         )
+        # Accessing ``YOLO.names`` can initialize an ONNX backend. Capture it
+        # once on the preparation worker instead of repeatedly from the UI.
+        self.model_names = {
+            int(class_id): str(class_name)
+            for class_id, class_name in self.model.names.items()
+        }
         self.device = self._preferred_device_for_model(self.model_path)
 
     @staticmethod

--- a/taggui/auto_marking/model_cache.py
+++ b/taggui/auto_marking/model_cache.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from utils.marking_model_security import (
+    configure_ultralytics_marking_runtime,
+    infer_marking_model_task,
+)
+
+
+_METADATA_CACHE_PATH = (
+    Path.home() / ".taggui_cache" / "marking_models" / "class_metadata.json"
+)
+_CACHE_LOCK = threading.RLock()
+_RUNTIME_CACHE: dict[tuple[str, int, int], "MarkingRuntime"] = {}
+
+
+@dataclass
+class MarkingRuntime:
+    model: object
+    device: str
+    model_names: dict[int, str]
+    inference_lock: threading.RLock
+
+
+def _model_signature(model_path: Path | str) -> tuple[str, int, int]:
+    path = Path(model_path).expanduser().resolve()
+    stat = path.stat()
+    return str(path), int(stat.st_size), int(stat.st_mtime_ns)
+
+
+def _preferred_device(model_path: Path) -> str:
+    import torch
+
+    if not torch.cuda.is_available():
+        return "cpu"
+    if model_path.suffix.lower() != ".onnx":
+        return "cuda"
+    try:
+        import onnxruntime
+    except Exception:
+        return "cpu"
+    return (
+        "cuda"
+        if "CUDAExecutionProvider" in onnxruntime.get_available_providers()
+        else "cpu"
+    )
+
+
+def load_marking_runtime(model_path: Path | str) -> MarkingRuntime:
+    signature = _model_signature(model_path)
+    with _CACHE_LOCK:
+        cached = _RUNTIME_CACHE.get(signature)
+        if cached is not None:
+            return cached
+
+        from ultralytics import YOLO
+
+        path = Path(signature[0])
+        configure_ultralytics_marking_runtime(path)
+        model = YOLO(path, task=infer_marking_model_task(path))
+        model_names = {
+            int(class_id): str(class_name)
+            for class_id, class_name in model.names.items()
+        }
+        runtime = MarkingRuntime(
+            model=model,
+            device=_preferred_device(path),
+            model_names=model_names,
+            inference_lock=threading.RLock(),
+        )
+        _RUNTIME_CACHE[signature] = runtime
+        _write_class_metadata(signature, model_names)
+        return runtime
+
+
+def get_cached_model_classes(
+        model_path: Path | str) -> dict[int, str] | None:
+    try:
+        signature = _model_signature(model_path)
+    except OSError:
+        return None
+    with _CACHE_LOCK:
+        runtime = _RUNTIME_CACHE.get(signature)
+        if runtime is not None:
+            return dict(runtime.model_names)
+        payload = _read_metadata_payload()
+        entry = payload.get(signature[0])
+        if not isinstance(entry, dict):
+            return None
+        if (
+            int(entry.get("size", -1)) != signature[1]
+            or int(entry.get("mtime_ns", -1)) != signature[2]
+        ):
+            return None
+        classes = entry.get("classes")
+        if not isinstance(classes, dict):
+            return None
+        try:
+            return {
+                int(class_id): str(class_name)
+                for class_id, class_name in classes.items()
+            }
+        except (TypeError, ValueError):
+            return None
+
+
+def _read_metadata_payload() -> dict:
+    try:
+        with _METADATA_CACHE_PATH.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (FileNotFoundError, OSError, TypeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_class_metadata(
+        signature: tuple[str, int, int],
+        model_names: dict[int, str],
+):
+    payload = _read_metadata_payload()
+    payload[signature[0]] = {
+        "size": signature[1],
+        "mtime_ns": signature[2],
+        "classes": {
+            str(class_id): str(class_name)
+            for class_id, class_name in model_names.items()
+        },
+    }
+    try:
+        _METADATA_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = _METADATA_CACHE_PATH.with_suffix(".tmp")
+        with temporary_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, sort_keys=True)
+        os.replace(temporary_path, _METADATA_CACHE_PATH)
+    except OSError:
+        return

--- a/taggui/controllers/pipeline_runner.py
+++ b/taggui/controllers/pipeline_runner.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 from PySide6.QtCore import QModelIndex, QObject, Qt, QTimer, Signal
 
-from auto_captioning.captioning_thread import CaptioningThread
-from auto_marking.marking_thread import MarkingThread
 from utils.auto_marking_preferences import saved_class_labels_for_model
 from utils.ideogram_caption import (
     IdeogramCaptionError,
@@ -127,6 +125,8 @@ class PipelineRunner(QObject):
             self._finish(False, f"{title} failed: {exc}")
 
     def _start_auto_mark(self, step: PipelineStep):
+        from auto_marking.marking_thread import MarkingThread
+
         model_value = str(step.settings.get("model") or "").strip()
         if not model_value:
             model_value = str(
@@ -293,6 +293,7 @@ class PipelineRunner(QObject):
         for entry in group_results.values():
             markings = list(entry["markings"])
             raw_count += len(markings)
+            from auto_marking.marking_thread import MarkingThread
             fused = MarkingThread._merge_overlapping_markings(
                 markings,
                 threshold,
@@ -357,6 +358,8 @@ class PipelineRunner(QObject):
         return len(unique)
 
     def _start_auto_caption(self, step: PipelineStep):
+        from auto_captioning.captioning_thread import CaptioningThread
+
         form = self.main_window.auto_captioner.caption_settings_form
         caption_settings = form.get_caption_settings()
         model_id = str(step.settings.get("model") or "").strip()

--- a/taggui/controllers/signal_manager.py
+++ b/taggui/controllers/signal_manager.py
@@ -479,68 +479,19 @@ class SignalManager:
         )
 
     def connect_video_controls_signals(self):
-        """Connect video player and controls signals."""
-        video_player = self.main_window.image_viewer.video_player
-        video_controls = self.main_window.image_viewer.video_controls
+        """Connect persistent toolbar actions and lazy main-viewer video wiring."""
+        viewer = self.main_window.image_viewer
         toolbar_manager = self.main_window.toolbar_manager
         video_editing_controller = self.main_window.video_editing_controller
 
-        # Connect video controls to video player
-        def on_play_pause_requested():
-            """Handle manual play/pause toggle from user."""
-            self.main_window.toggle_viewer_play_pause(self.main_window.image_viewer)
-
-        video_controls.play_pause_requested.connect(on_play_pause_requested)
-        video_controls.stop_requested.connect(video_player.stop)
-        video_controls.frame_changed.connect(video_player.seek_to_frame)
-        video_controls.timeline_slider.scrub_started.connect(video_player.begin_timeline_scrub)
-        video_controls.timeline_slider.sliderReleased.connect(video_player.end_timeline_scrub)
-        # Connect marker preview - seeks video without updating controls
-        video_controls.marker_preview_requested.connect(video_player.seek_to_frame)
-        video_controls.skip_back_btn.clicked.connect(
-            lambda checked=False: self.main_window.image_viewer.handle_video_controls_skip_button_step('backward')
+        viewer.video_components_ready.connect(
+            self.main_window._connect_viewer_video_controls
         )
-        video_controls.skip_forward_btn.clicked.connect(
-            lambda checked=False: self.main_window.image_viewer.handle_video_controls_skip_button_step('forward')
-        )
-
-        # Connect video player updates to video controls
-        video_player.frame_changed.connect(
-            lambda frame, time_ms: self.main_window._queue_video_controls_update(
-                self.main_window.image_viewer, frame, time_ms
-            )
-        )
-        video_player.playback_started.connect(
-            lambda: video_controls.set_playing(True)
-        )
-        video_player.playback_paused.connect(
-            lambda: video_controls.set_playing(False)
-        )
-        video_player.playback_finished.connect(
-            lambda: video_controls.set_playing(False)
-        )
-
-        # Connect loop controls
-        video_controls.loop_toggled.connect(lambda enabled: self._update_loop_state())
-        video_controls.loop_start_set.connect(lambda: self._update_loop_state())
-        video_controls.loop_end_set.connect(lambda: self._update_loop_state())
-        video_controls.loop_reset.connect(
-            lambda: self._update_loop_state())
-
-        # Connect speed control
-        video_controls.speed_changed.connect(video_player.set_playback_speed)
-
-        # Connect mute control
-        video_controls.mute_toggled.connect(
-            lambda muted: video_player.set_muted(muted))
-        video_controls.volume_changed.connect(
-            lambda volume: video_player.set_volume(volume))
+        self.main_window._connect_viewer_video_controls(viewer)
 
         # Connect toolbar video editing controls
         toolbar_manager.fixed_marker_size_spinbox.valueChanged.connect(
             lambda value: self._on_marker_size_changed(value))
-        # Initialize video_controls.fixed_marker_size from saved settings
-        video_controls.fixed_marker_size = toolbar_manager.fixed_marker_size_spinbox.value()
 
         toolbar_manager.always_show_controls_action.triggered.connect(
             toolbar_manager.cycle_main_viewer_video_controls_visibility_mode
@@ -560,11 +511,6 @@ class SignalManager:
             video_editing_controller.remove_video_frame)
         toolbar_manager.repeat_frame_action.triggered.connect(
             video_editing_controller.repeat_video_frame)
-        video_controls.screenshot_requested.connect(
-            lambda: video_editing_controller.capture_current_video_frame(
-                viewer=self.main_window.image_viewer
-            )
-        )
         toolbar_manager.fix_frame_count_btn.clicked.connect(
             video_editing_controller.fix_video_frame_count)
         toolbar_manager.fix_all_folder_btn.clicked.connect(
@@ -617,7 +563,8 @@ class SignalManager:
     def _on_marker_size_changed(self, value):
         """Handle marker size changes and save to settings."""
         video_controls = self.main_window.image_viewer.video_controls
-        setattr(video_controls, 'fixed_marker_size', value)
+        if video_controls is not None:
+            setattr(video_controls, 'fixed_marker_size', value)
         settings.setValue('fixed_marker_size', value)
 
     def _update_delete_button_visibility(self):

--- a/taggui/controllers/video_editing_controller.py
+++ b/taggui/controllers/video_editing_controller.py
@@ -6,7 +6,6 @@ from PySide6.QtWidgets import QMessageBox, QInputDialog, QProgressDialog
 from PySide6.QtCore import Qt, QTimer
 from collections import deque
 
-from utils.video_editor import VideoEditor
 from utils.sidecar import (
     copy_existing_json_sidecars,
     is_taggui_metadata_dict,
@@ -17,6 +16,12 @@ from utils.sidecar import (
 )
 import subprocess
 import json
+
+
+def _video_editor_class():
+    """Resolve editing backends only when the user invokes an edit command."""
+    from utils.video_editor import VideoEditor
+    return VideoEditor
 
 
 class VideoEditingController:
@@ -504,7 +509,7 @@ class VideoEditingController:
 
             # Extract directly to the new file. Do not create a temporary full copy first,
             # otherwise the new copy incorrectly receives its own .backup files.
-            success, message = VideoEditor.extract_range_rough(
+            success, message = _video_editor_class().extract_range_rough(
                 input_path, new_path,
                 start_frame, end_frame, fps
             )
@@ -538,7 +543,7 @@ class VideoEditingController:
             self._prepare_video_for_editing(video_player)
 
             # Extract range (overwrites original, creates backup)
-            success, message = VideoEditor.extract_range_rough(
+            success, message = _video_editor_class().extract_range_rough(
                 input_path, input_path,
                 start_frame, end_frame, fps
             )
@@ -698,7 +703,7 @@ class VideoEditingController:
 
             # Extract directly to the new file so extract-as-copy does not generate
             # .backup files for the newly created clip.
-            success, message = VideoEditor.extract_range(
+            success, message = _video_editor_class().extract_range(
                 input_path, new_path,
                 start_frame, end_frame, fps,
                 reverse=reverse,
@@ -735,7 +740,7 @@ class VideoEditingController:
             self._prepare_video_for_editing(video_player)
 
             # Extract range with optional speed/FPS changes (all in one ffmpeg pass)
-            success, message = VideoEditor.extract_range(
+            success, message = _video_editor_class().extract_range(
                 input_path, input_path,
                 start_frame, end_frame, fps,
                 reverse=reverse,
@@ -881,7 +886,7 @@ class VideoEditingController:
         self._prepare_video_for_editing(video_player)
 
         # Remove range (overwrites original, creates backup)
-        success, message = VideoEditor.remove_range(
+        success, message = _video_editor_class().remove_range(
             input_path, input_path,
             start_frame, end_frame, fps
         )
@@ -924,7 +929,7 @@ class VideoEditingController:
         self._prepare_video_for_editing(video_player)
 
         # Remove frame
-        success, message = VideoEditor.remove_frame(
+        success, message = _video_editor_class().remove_frame(
             input_path, input_path,
             current_frame, fps
         )
@@ -980,7 +985,7 @@ class VideoEditingController:
         self._prepare_video_for_editing(video_player)
 
         # Repeat frame
-        success, message = VideoEditor.repeat_frame(
+        success, message = _video_editor_class().repeat_frame(
             input_path, input_path,
             current_frame, repeat_count, fps
         )
@@ -1075,7 +1080,7 @@ class VideoEditingController:
                 self._save_undo_snapshot(video_path, "Fix N*4+1 frame count (single)")
 
                 # Fix frame count
-                success, message = VideoEditor.fix_frame_count_to_n4_plus_1(
+                success, message = _video_editor_class().fix_frame_count_to_n4_plus_1(
                     video_path, video_path, fps, repeat_last, None
                 )
 
@@ -1188,7 +1193,7 @@ class VideoEditingController:
                 self._save_undo_snapshot(video_path, "Fix N*4+1 frame count (batch)")
 
                 # Fix frame count
-                success, message = VideoEditor.fix_frame_count_to_n4_plus_1(
+                success, message = _video_editor_class().fix_frame_count_to_n4_plus_1(
                     video_path, video_path, fps, repeat_last, None
                 )
 
@@ -1250,7 +1255,7 @@ class VideoEditingController:
         # Scan for non-square SAR videos
         non_square_videos = []
         for video_path in video_paths:
-            sar_num, sar_den, dims = VideoEditor.check_sar(video_path)
+            sar_num, sar_den, dims = _video_editor_class().check_sar(video_path)
             if sar_num and sar_den and sar_num != sar_den:
                 non_square_videos.append((video_path, sar_num, sar_den))
 
@@ -1287,7 +1292,7 @@ class VideoEditingController:
             progress.setValue(current)
             return progress.wasCanceled()
 
-        success_count, error_count, errors = VideoEditor.batch_fix_sar(
+        success_count, error_count, errors = _video_editor_class().batch_fix_sar(
             [v[0] for v in non_square_videos],
             progress_callback=update_progress
         )
@@ -1331,7 +1336,7 @@ class VideoEditingController:
             return
 
         # Scan for non-square SAR videos
-        non_square_videos = VideoEditor.scan_directory_for_non_square_sar(
+        non_square_videos = _video_editor_class().scan_directory_for_non_square_sar(
             self.main_window.directory_path, video_extensions
         )
 
@@ -1369,7 +1374,7 @@ class VideoEditingController:
             progress.setValue(current)
             return progress.wasCanceled()
 
-        success_count, error_count, errors = VideoEditor.batch_fix_sar(
+        success_count, error_count, errors = _video_editor_class().batch_fix_sar(
             [v[0] for v in non_square_videos],
             progress_callback=update_progress_all
         )
@@ -1514,7 +1519,7 @@ class VideoEditingController:
         self._prepare_video_for_editing(video_player)
 
         # Apply speed change
-        success, message = VideoEditor.change_speed(
+        success, message = _video_editor_class().change_speed(
             input_path, input_path,
             final_speed, target_fps
         )
@@ -1621,7 +1626,7 @@ class VideoEditingController:
         self._prepare_video_for_editing(video_player)
 
         # Apply FPS change
-        success, message = VideoEditor.change_fps(
+        success, message = _video_editor_class().change_fps(
             input_path, input_path,
             target_fps
         )

--- a/taggui/dialogs/batch_reorder_tags_dialog.py
+++ b/taggui/dialogs/batch_reorder_tags_dialog.py
@@ -1,13 +1,26 @@
 import re
 
 from PySide6.QtCore import Slot
-from PySide6.QtWidgets import QDialog, QHBoxLayout, QMessageBox, QPushButton, QVBoxLayout
+from PySide6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+)
 
 from models.image_list_model import ImageListModel
 from models.tag_counter_model import TagCounterModel
 from utils.settings_widgets import SettingsBigCheckBox, SettingsLineEdit
 from utils.utils import get_confirmation_dialog_reply
-from widgets.auto_captioner import HorizontalLine
+
+
+def _horizontal_line() -> QFrame:
+    line = QFrame()
+    line.setFrameShape(QFrame.Shape.HLine)
+    line.setFrameShadow(QFrame.Shadow.Raised)
+    return line
 
 
 class BatchReorderTagsDialog(QDialog):
@@ -56,7 +69,7 @@ class BatchReorderTagsDialog(QDialog):
                     do_not_reorder_first_tag_check_box.isChecked())))
         top_buttons_layout.addWidget(shuffle_button)
         top_layout.addLayout(top_buttons_layout)
-        horizontal_line = HorizontalLine()
+        horizontal_line = _horizontal_line()
         middle_layout = QHBoxLayout()
         middle_layout.setContentsMargins(20, 20, 20, 20)
         middle_layout.setSpacing(20)
@@ -71,7 +84,7 @@ class BatchReorderTagsDialog(QDialog):
                 lambda: self.image_list_model.sort_sentences_down(
                     separate_newline_check_box.isChecked())))
         middle_layout.addWidget(sort_sentences_button)
-        horizontal_line2 = HorizontalLine()
+        horizontal_line2 = _horizontal_line()
         bottom_layout = QVBoxLayout()
         bottom_layout.setContentsMargins(20, 20, 20, 20)
         bottom_layout.setSpacing(20)

--- a/taggui/dialogs/settings_dialog.py
+++ b/taggui/dialogs/settings_dialog.py
@@ -30,12 +30,9 @@ from utils.settings import (
 from utils.video.playback_backend import (
     PLAYBACK_BACKEND_CHOICES,
     PLAYBACK_BACKEND_QT_HYBRID,
-    MPV_BACKEND_AVAILABLE,
-    MPV_BACKEND_ERROR,
     MPV_RUNTIME_SEARCHED_DIRS,
-    VLC_BACKEND_AVAILABLE,
-    VLC_BACKEND_ERROR,
     VLC_RUNTIME_SEARCHED_DIRS,
+    get_playback_backend_status,
     resolve_runtime_playback_backend,
     normalize_playback_backend_name,
 )
@@ -2323,6 +2320,8 @@ class SettingsDialog(QDialog):
     def _add_gpu_video_settings(self, grid_layout: QGridLayout, start_row: int):
         """Add advanced GPU/video backend settings block."""
         row = start_row
+        mpv_available, mpv_error = get_playback_backend_status('mpv_experimental')
+        vlc_available, vlc_error = get_playback_backend_status('vlc_experimental')
 
         # Playback backend selector (migration scaffold; runtime currently falls back to qt_hybrid)
         grid_layout.addWidget(QLabel('Video playback backend'), row, 0,
@@ -2337,11 +2336,11 @@ class SettingsDialog(QDialog):
             'qt_hybrid: Current stable backend (Qt + OpenCV hybrid).\n'
             'mpv_experimental: Experimental MPV backend.\n'
             'vlc_experimental: Experimental libVLC backend.\n\n'
-            f'mpv availability in current runtime: {"yes" if MPV_BACKEND_AVAILABLE else "no"}.\n'
-            f'vlc availability in current runtime: {"yes" if VLC_BACKEND_AVAILABLE else "no"}.\n'
+            f'mpv availability in current runtime: {"yes" if mpv_available else "no"}.\n'
+            f'vlc availability in current runtime: {"yes" if vlc_available else "no"}.\n'
             'When unavailable, selected experimental backend falls back to qt_hybrid.\n'
-            + (f'\nmpv load error: {MPV_BACKEND_ERROR}' if (not MPV_BACKEND_AVAILABLE and MPV_BACKEND_ERROR) else '')
-            + (f'\nvlc load error: {VLC_BACKEND_ERROR}' if (not VLC_BACKEND_AVAILABLE and VLC_BACKEND_ERROR) else '')
+            + (f'\nmpv load error: {mpv_error}' if (not mpv_available and mpv_error) else '')
+            + (f'\nvlc load error: {vlc_error}' if (not vlc_available and vlc_error) else '')
             + (
                 f"\n\nSearched runtime dirs:\n- " + "\n- ".join(MPV_RUNTIME_SEARCHED_DIRS[:6])
                 if MPV_RUNTIME_SEARCHED_DIRS else
@@ -2629,20 +2628,21 @@ class SettingsDialog(QDialog):
     def _on_playback_backend_changed(self, backend_name: str):
         configured = normalize_playback_backend_name(backend_name)
         runtime_backend = resolve_runtime_playback_backend(configured)
+        backend_available, backend_error = get_playback_backend_status(configured)
         show_mpv_download = (
             configured == 'mpv_experimental'
-            and not MPV_BACKEND_AVAILABLE
+            and not backend_available
             and sys.platform.startswith('win')
         )
         self.mpv_download_btn.setVisible(show_mpv_download)
         if configured != runtime_backend:
             extra = ''
-            if configured == 'mpv_experimental' and MPV_BACKEND_ERROR:
-                extra = f' ({MPV_BACKEND_ERROR})'
+            if configured == 'mpv_experimental' and backend_error:
+                extra = f' ({backend_error})'
                 if not MPV_RUNTIME_SEARCHED_DIRS and sys.platform.startswith('win'):
                     extra += " Place libmpv-2.dll in 'third_party/mpv/windows-x86_64/'."
-            elif configured == 'vlc_experimental' and VLC_BACKEND_ERROR:
-                extra = f' ({VLC_BACKEND_ERROR})'
+            elif configured == 'vlc_experimental' and backend_error:
+                extra = f' ({backend_error})'
                 if not VLC_RUNTIME_SEARCHED_DIRS and sys.platform.startswith('win'):
                     extra += " Place libvlc.dll/libvlccore.dll in 'third_party/vlc/windows-x86_64/'."
             self.warning_label.setText(

--- a/taggui/models/image_list_model.py
+++ b/taggui/models/image_list_model.py
@@ -7,24 +7,21 @@ import subprocess
 import sys
 import os
 import time
-import multiprocessing
 from typing import List, Dict, Any, Optional
 from collections import Counter, deque
 from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
 from math import floor, ceil
 from pathlib import Path
 import json
 
-import cv2
-import exifread
-import imagesize
 from PySide6.QtCore import (QAbstractListModel, QModelIndex, QMimeData, QPoint,
                             QRect, QSize, Qt, QUrl, Signal, Slot, QEvent, QMetaObject, Q_ARG, QTimer)
 from PySide6.QtGui import QIcon, QImage, QImageReader, QPixmap
 from PySide6.QtWidgets import QMessageBox, QApplication
 from PIL import Image as pilimage  # Import Pillow's Image class
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 import threading
 
 
@@ -63,6 +60,22 @@ import utils.target_dimension as target_dimension
 ensure_pillow_plugins_registered()
 
 UNDO_STACK_SIZE = 32
+
+
+@lru_cache(maxsize=1)
+def _get_exifread_module():
+    """Load EXIF parsing only when uncached image metadata needs it."""
+    import exifread
+
+    return exifread
+
+
+@lru_cache(maxsize=1)
+def _get_imagesize_module():
+    """Load header-based dimension parsing only when a directory is loaded."""
+    import imagesize
+
+    return imagesize
 
 # Global lock for video operations (OpenCV/ffmpeg is not thread-safe)
 _video_lock = threading.Lock()
@@ -111,6 +124,8 @@ def cv2_to_qimage(image_array) -> QImage | None:
     if image_array is None:
         return None
     try:
+        import cv2
+
         if len(image_array.shape) == 2:
             height, width = image_array.shape
             bytes_per_line = width
@@ -359,6 +374,8 @@ def fallback_decode_qimage(path: Path) -> tuple[QImage | None, tuple[int, int] |
         pass
 
     try:
+        import cv2
+
         image_array = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
         qimage = cv2_to_qimage(image_array)
         if qimage is not None and not qimage.isNull():
@@ -1449,6 +1466,8 @@ def extract_video_info(video_path: Path) -> tuple[tuple[int, int] | None, dict |
     """
     with _video_lock:
         try:
+            import cv2
+
             # Force software decoding (CAP_FFMPEG backend, no DXVA/D3D11 HW accel).
             # OpenCV is built with DXVA + NVD3D11 support — if hw accel is active while
             # MPV's D3D11 renderer is running, both fight over the D3D11 device and trigger
@@ -2201,6 +2220,9 @@ class ImageListModel(QAbstractListModel):
         if self._scan_process_disabled or self._scan_process_executor is not None:
             return
         try:
+            import multiprocessing
+            from concurrent.futures import ProcessPoolExecutor
+
             spawn_context = multiprocessing.get_context("spawn")
             self._scan_process_executor = ProcessPoolExecutor(
                 max_workers=1,
@@ -4267,13 +4289,16 @@ class ImageListModel(QAbstractListModel):
             for image in self.images:
                 if image.thumbnail or image.thumbnail_qimage:
                     continue
-                # Quick cache check (doesn't load, just checks if file exists)
                 try:
                     mtime = image.path.stat().st_mtime
-                    if not cache.get_thumbnail(image.path, mtime, self.thumbnail_generation_width):
+                    if not cache.has_thumbnail(image.path, mtime, self.thumbnail_generation_width):
                         uncached_count += 1
                 except:
                     uncached_count += 1
+                # The exact count is only needed below this threshold. Once
+                # reached, the submission pass will inspect every candidate.
+                if uncached_count >= 50:
+                    break
 
             # Pagination mode always needs smart preload for smoothness
             # Normal mode can skip if mostly cached
@@ -4281,7 +4306,7 @@ class ImageListModel(QAbstractListModel):
                 print(f"[THUMBNAIL] Only {uncached_count} uncached, using on-demand loading")
                 return
 
-            print(f"[THUMBNAIL] {uncached_count} uncached images, starting parallel loading")
+            print(f"[THUMBNAIL] At least {uncached_count} uncached images, starting parallel loading")
             preload_limit = None  # Preload all
 
         # Cancel any existing thumbnail loading
@@ -4316,9 +4341,7 @@ class ImageListModel(QAbstractListModel):
             if cache.enabled:
                 try:
                     mtime = image.path.stat().st_mtime
-                    cache_key = cache._get_cache_key(image.path, mtime, self.thumbnail_generation_width)
-                    cache_path = cache._get_cache_path(cache_key)
-                    if cache_path.exists():
+                    if cache.has_thumbnail(image.path, mtime, self.thumbnail_generation_width):
                         skipped_cache += 1
                         continue  # Don't submit - will be loaded on-demand from cache
                 except Exception:
@@ -4328,8 +4351,7 @@ class ImageListModel(QAbstractListModel):
                 self._load_thumbnail_worker, idx, image.path, image.crop,
                 self.thumbnail_generation_width, image.is_video
             )
-            with self._thumbnail_lock:
-                self._thumbnail_futures[idx] = future
+            self._track_thumbnail_future(idx, image.path, future)
             submitted += 1
 
         if checked < total_images:
@@ -4363,8 +4385,23 @@ class ImageListModel(QAbstractListModel):
             self._load_thumbnail_worker, idx, image.path, image.crop,
             self.thumbnail_generation_width, image.is_video
         )
+        self._track_thumbnail_future(idx, image.path, future)
+
+    def _track_thumbnail_future(self, idx: int, path: Path, future):
+        """Register a thumbnail task before allowing completion cleanup."""
         with self._thumbnail_lock:
-            self._thumbnail_futures[idx] = future
+            self._thumbnail_futures[idx] = (future, path)
+        future.add_done_callback(
+            lambda completed, row=idx: self._forget_thumbnail_future(row, completed)
+        )
+
+    def _forget_thumbnail_future(self, idx: int, completed_future):
+        """Remove only the task that currently owns a row's future slot."""
+        with self._thumbnail_lock:
+            entry = self._thumbnail_futures.get(idx)
+            current_future = entry[0] if isinstance(entry, tuple) else entry
+            if current_future is completed_future:
+                self._thumbnail_futures.pop(idx, None)
 
     def _report_cache_progress(self):
         """Periodically report thumbnail cache save progress."""
@@ -4685,14 +4722,17 @@ class ImageListModel(QAbstractListModel):
             qimage, was_cached, _, resolved_path = load_thumbnail_data(path, crop, width, is_video)
 
             if qimage and not qimage.isNull():
-                # Find image by PATH, not by idx (array may have been sorted!)
-                for img in self.images:
-                    if img.path == path:
-                        if resolved_path != path:
-                            img.path = resolved_path
-                        img.thumbnail_qimage = qimage
-                        img._last_thumbnail_was_cached = was_cached
-                        break
+                # In the common case the row has not moved since submission.
+                # Preserve the path fallback for a concurrent sort/reorder.
+                img = self.images[idx] if 0 <= idx < len(self.images) else None
+                if img is None or img.path != path:
+                    img = next((candidate for candidate in self.images
+                                if candidate.path == path), None)
+                if img is not None:
+                    if resolved_path != path:
+                        img.path = resolved_path
+                    img.thumbnail_qimage = qimage
+                    img._last_thumbnail_was_cached = was_cached
 
                 # DON'T emit dataChanged - let Qt request thumbnails on-demand
                 # Emitting 1147 dataChanged signals floods the event queue
@@ -4701,11 +4741,6 @@ class ImageListModel(QAbstractListModel):
             print(f"Error in thumbnail worker for {path}: {e}")
             import traceback
             traceback.print_exc()
-        finally:
-            # Remove from futures dict
-            with self._thumbnail_lock:
-                self._thumbnail_futures.pop(idx, None)
-
     def _save_thumbnail_worker(self, path: Path, mtime: float, width: int, qimage):
         """Worker function that saves thumbnail QImage to disk cache.
 
@@ -5403,7 +5438,6 @@ class ImageListModel(QAbstractListModel):
              from utils.image import Image
              import time
              from pathlib import Path
-             import imagesize
 
              if generation != int(getattr(self, '_enrichment_generation', 0) or 0):
                  return
@@ -5590,7 +5624,7 @@ class ImageListModel(QAbstractListModel):
                          dimensions = get_jxl_size(full_path)
                       else:
                           # Try fast imagesize first
-                          dimensions = imagesize.get(str(full_path))
+                          dimensions = _get_imagesize_module().get(str(full_path))
                           
                           # HEURISTIC CHECK:
                           # If dimensions seem "Impossible" or "Suspicious" (Super Tall/Fat),
@@ -5908,7 +5942,7 @@ class ImageListModel(QAbstractListModel):
     def _validate_cached_paths_in_background(
         self,
         directory_path: Path,
-        cached_rel_paths: list[str],
+        cached_rel_paths: list[str] | None,
         image_suffixes: list[str],
         generation: int,
     ):
@@ -5923,23 +5957,46 @@ class ImageListModel(QAbstractListModel):
                 self.background_validation_progress.emit(label, current, maximum, done)
                 return True
 
-            norm_to_cached_paths = {}
-            for rel_path in cached_rel_paths:
-                normalized = _normalize_relative_path(rel_path)
-                norm_to_cached_paths.setdefault(normalized, []).append(rel_path)
+            stored_dir_mtimes = db.get_directory_signatures()
+            changed_roots = (
+                get_changed_directory_roots(directory_path, stored_dir_mtimes)
+                if stored_dir_mtimes
+                else [""]
+            )
+            if (
+                cached_rel_paths is None
+                and stored_dir_mtimes
+                and not changed_roots
+            ):
+                print("[CACHE] Background validation complete: no directory changes detected")
+                self._queue_path_validation_result({
+                    'generation': generation,
+                    'directory_path': directory_path,
+                    'changes_detected': False,
+                })
+                _emit_progress("", -1, 0, True)
+                return
+
+            if cached_rel_paths is None:
+                cached_rel_paths = db.get_all_paths()
 
             current_rel_map = {}
             duplicate_db_paths = []
-            for normalized, rel_variants in norm_to_cached_paths.items():
-                unique_variants = sorted(set(rel_variants))
-                current_rel_map[normalized] = unique_variants[0]
-                if len(unique_variants) > 1:
-                    duplicate_db_paths.extend(unique_variants[1:])
-            current_rel_paths = set(current_rel_map.keys())
-            stored_dir_mtimes = db.get_directory_signatures()
-
+            for rel_path in cached_rel_paths:
+                normalized = _normalize_relative_path(rel_path)
+                existing = current_rel_map.get(normalized)
+                if existing is None:
+                    current_rel_map[normalized] = rel_path
+                    continue
+                if rel_path == existing:
+                    continue
+                if rel_path < existing:
+                    duplicate_db_paths.append(existing)
+                    current_rel_map[normalized] = rel_path
+                else:
+                    duplicate_db_paths.append(rel_path)
+            current_rel_paths = current_rel_map.keys()
             if stored_dir_mtimes:
-                changed_roots = get_changed_directory_roots(directory_path, stored_dir_mtimes)
                 if not changed_roots:
                     duplicate_db_paths = sorted(set(duplicate_db_paths))
                     if duplicate_db_paths:
@@ -6129,7 +6186,11 @@ class ImageListModel(QAbstractListModel):
         # Try to load file paths from DB cache first (much faster for large folders)
         from utils.image_index_db import ImageIndexDB
         db = ImageIndexDB(directory_path)
-        cached_paths = db.get_all_paths()
+        # A COUNT is effectively free in SQLite, while materializing 1M path
+        # strings costs seconds and hundreds of MB. The paginated fast path
+        # only needs the count; its deferred validator loads paths off-thread.
+        cached_count = int(db.count() or 0)
+        cached_paths = None
         stored_dir_mtimes = db.get_directory_signatures()
         cache_stats = None
         dir_mtimes = None
@@ -6171,7 +6232,7 @@ class ImageListModel(QAbstractListModel):
                 self._load_executor.submit(
                     self._validate_cached_paths_in_background,
                     directory_path,
-                    list(cached_paths),
+                    list(cached_paths) if cached_paths is not None else None,
                     list(image_suffixes),
                     load_generation,
                 )
@@ -6211,7 +6272,6 @@ class ImageListModel(QAbstractListModel):
                 dialog.setLabelText(f"{label}\nFiles: {int(count):,}")
             QApplication.processEvents()
 
-        cached_count = len({_normalize_relative_path(rel_path) for rel_path in cached_paths})
         precomputed_count = len(precomputed_rel_paths) if precomputed_rel_paths is not None else None
         if normalized_load_options is not None and precomputed_rel_paths is not None:
             limited_precomputed_rel_paths = db.get_limited_paths(normalized_load_options)
@@ -6309,7 +6369,8 @@ class ImageListModel(QAbstractListModel):
         try:
             if precomputed_rel_paths is not None:
                 file_paths = {directory_path / rel_path for rel_path in precomputed_rel_paths}
-            elif cached_paths and len(cached_paths) > 1000:
+            elif cached_count > 1000:
+                cached_paths = db.get_all_paths()
                 _update_scan_progress("Checking folder changes...")
                 fs_count, fs_tree_mtime = get_directory_tree_stats(
                     directory_path,
@@ -6596,7 +6657,7 @@ class ImageListModel(QAbstractListModel):
                         elif str(image_path).endswith('jxl'):
                             dimensions = get_jxl_size(image_path)
                         else:
-                            dimensions = imagesize.get(str(image_path))
+                            dimensions = _get_imagesize_module().get(str(image_path))
                             if dimensions == (-1, -1):
                                 dimensions = pilimage.open(image_path).size
 
@@ -6618,7 +6679,7 @@ class ImageListModel(QAbstractListModel):
                 if not cached and not is_video:
                     try:
                         with open(image_path, 'rb') as image_file:
-                            exif_tags = exifread.process_file(
+                            exif_tags = _get_exifread_module().process_file(
                                 image_file, details=False, extract_thumbnail=False,
                                 stop_tag='Image Orientation')
                             if 'Image Orientation' in exif_tags:
@@ -6760,7 +6821,7 @@ class ImageListModel(QAbstractListModel):
                         elif str(image.path).endswith('jxl'):
                             dimensions = get_jxl_size(image.path)
                         else:
-                            dimensions = imagesize.get(str(image.path))
+                            dimensions = _get_imagesize_module().get(str(image.path))
                             if dimensions == (-1, -1):
                                 dimensions = pilimage.open(image.path).size
 
@@ -6771,7 +6832,7 @@ class ImageListModel(QAbstractListModel):
                         if not is_video:
                             try:
                                 with open(image.path, 'rb') as image_file:
-                                    exif_tags = exifread.process_file(
+                                    exif_tags = _get_exifread_module().process_file(
                                         image_file, details=False, extract_thumbnail=False,
                                         stop_tag='Image Orientation')
                                     if 'Image Orientation' in exif_tags:
@@ -7130,11 +7191,26 @@ class ImageListModel(QAbstractListModel):
         # Emit signal
         self.total_count_changed.emit(self._total_count)
 
-        # Bootstrap: Load first 3 pages immediately so UI has something to show
-        print(f"[PAGINATION] Loading first 3 pages to bootstrap UI...")
-        for page_num in range(min(3, (self._total_count + self.PAGE_SIZE - 1) // self.PAGE_SIZE)):
-            self._load_page_sync(page_num)
-        print(f"[PAGINATION] Loaded {len(self._pages)} pages initially")
+        # Bootstrap one page synchronously so the first 1,000 items become
+        # usable quickly. Fill the existing three-page warm window in the
+        # background; page_loaded/pages_updated already append those pages
+        # without blocking the UI thread.
+        bootstrap_page_count = min(
+            3,
+            (self._total_count + self.PAGE_SIZE - 1) // self.PAGE_SIZE,
+        )
+        print(
+            "[PAGINATION] Loading first page synchronously; "
+            f"warming {max(0, bootstrap_page_count - 1)} adjacent page(s)..."
+        )
+        if bootstrap_page_count > 0:
+            self._load_page_sync(0)
+        for page_num in range(1, bootstrap_page_count):
+            self._request_page_load(page_num)
+        print(
+            f"[PAGINATION] Loaded {len(self._pages)} page(s) initially; "
+            f"{max(0, bootstrap_page_count - len(self._pages))} warming"
+        )
 
         # Trigger masonry calculation now that we have initial pages
         # CRITICAL: Emit pages_updated BEFORE layoutChanged so proxy invalidates first
@@ -7155,7 +7231,10 @@ class ImageListModel(QAbstractListModel):
         print(f"BUFFERED VIRTUAL PAGINATION: {self._total_count} images ready")
         print(f"Load time: {elapsed*1000:.0f}ms")
         print(f"Memory: Minimal (pages load on-demand)")
-        print(f"Pages: 0/{(total_images + self.PAGE_SIZE - 1) // self.PAGE_SIZE} loaded initially")
+        print(
+            f"Pages: {len(self._pages)}/"
+            f"{(total_images + self.PAGE_SIZE - 1) // self.PAGE_SIZE} loaded initially"
+        )
         print(f"Masonry: Calculated only for loaded pages (buffered range)")
         print(f"================================================================================")
 
@@ -9168,7 +9247,7 @@ class ImageListModel(QAbstractListModel):
                 # Only get EXIF for images, not videos
                 try:
                     with open(image_path, 'rb') as image_file:
-                        exif_tags = exifread.process_file(
+                        exif_tags = _get_exifread_module().process_file(
                             image_file, details=False, extract_thumbnail=False,
                             stop_tag='Image Orientation')
                         if 'Image Orientation' in exif_tags:

--- a/taggui/models/image_list_model.py
+++ b/taggui/models/image_list_model.py
@@ -3947,12 +3947,11 @@ class ImageListModel(QAbstractListModel):
         if not pages_to_reload and preloaded_pages:
             pages_to_reload = sorted(int(page_num) for page_num in preloaded_pages.keys())
 
-        if self._db is not None:
-            try:
-                self._db.close()
-            except Exception:
-                pass
-        self._db = ImageIndexDB(self._directory_path)
+        # The refresh worker committed through its own connection. Reuse the
+        # model's live wrapper so queued thumbnail metadata writes cannot race
+        # with closing and replacing its SQLite connection.
+        if self._db is None:
+            self._db = ImageIndexDB(self._directory_path)
 
         if self._active_load_options is not None:
             refreshed_scope_rel_paths = self._db.get_limited_paths(self._active_load_options)
@@ -4883,7 +4882,9 @@ class ImageListModel(QAbstractListModel):
                             pass
                 
                 # Update DB in background 
-                if self._db and self._save_executor:
+                db = self._db
+                save_executor = self._save_executor
+                if db is not None and save_executor is not None:
                     relative_path = None
                     try:
                         if self._directory_path:
@@ -4891,8 +4892,11 @@ class ImageListModel(QAbstractListModel):
                     except Exception:
                         relative_path = None
                     persist_key = relative_path or str(image.path)
-                    self._save_executor.submit(
-                        lambda key=persist_key, w=width, h=height: self._db.update_image_dimensions(key, w, h)
+                    save_executor.submit(
+                        db.update_image_dimensions,
+                        persist_key,
+                        width,
+                        height,
                     )
 
                 # Trigger debounced dimension update signal so masonry refreshes smoothly.
@@ -5843,12 +5847,11 @@ class ImageListModel(QAbstractListModel):
             and bool(result.get('db_synced'))
             and self._active_load_options is None
         ):
-            if self._db is not None:
-                try:
-                    self._db.close()
-                except Exception:
-                    pass
-            self._db = ImageIndexDB(self._directory_path)
+            # The validation worker committed through a separate connection;
+            # the existing wrapper can observe those commits without being
+            # closed underneath page and thumbnail workers.
+            if self._db is None:
+                self._db = ImageIndexDB(self._directory_path)
             snapshot_matches = (
                 str(result.get('filter_sql') or '') == str(self._filter_sql or '')
                 and tuple(result.get('filter_bindings') or ()) == tuple(self._filter_bindings or ())

--- a/taggui/skins/engine/skin_manager.py
+++ b/taggui/skins/engine/skin_manager.py
@@ -9,7 +9,12 @@ from .skin_applier import SkinApplier
 class SkinManager:
     """Manages skin loading, switching, and application."""
 
-    def __init__(self, skin_dirs: Optional[List[Path]] = None):
+    def __init__(
+        self,
+        skin_dirs: Optional[List[Path]] = None,
+        *,
+        discover_on_init: bool = True,
+    ):
         """Initialize skin manager.
 
         Args:
@@ -29,13 +34,46 @@ class SkinManager:
         self.current_applier: Optional[SkinApplier] = None
         self.current_skin_path: Optional[Path] = None  # Track current skin file path
         self.available_skins: List[Dict[str, Any]] = []
+        self._catalog_signature = None
 
-        # Load available skins
-        self.refresh_available_skins()
+        if discover_on_init:
+            self.refresh_available_skins()
+
+    def _iter_skin_files(self):
+        for skin_dir in self.skin_dirs:
+            if not skin_dir.exists():
+                continue
+            yield from skin_dir.glob('*.yaml')
+
+    def _skin_catalog_signature(self):
+        signature = []
+        for skin_path in self._iter_skin_files():
+            try:
+                stat = skin_path.stat()
+                signature.append(
+                    (str(skin_path), int(stat.st_mtime_ns), int(stat.st_size))
+                )
+            except OSError:
+                continue
+        return tuple(sorted(signature))
+
+    @staticmethod
+    def _skin_info(skin_path: Path, skin_data: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            'name': skin_data.get('name', skin_path.stem),
+            'author': skin_data.get('author', 'Unknown'),
+            'version': skin_data.get('version', '1.0'),
+            'path': skin_path,
+            'data': skin_data,
+        }
 
     def refresh_available_skins(self):
         """Refresh list of available skins."""
+        signature = self._skin_catalog_signature()
+        if self.available_skins and signature == self._catalog_signature:
+            return
         self.available_skins = self.loader.list_available_skins(self.skin_dirs)
+        self._catalog_signature = signature
 
     def get_available_skins(self) -> List[Dict[str, Any]]:
         """Get list of available skins.
@@ -60,6 +98,20 @@ class SkinManager:
             if skin['name'] == skin_name:
                 skin_info = skin
                 break
+
+        # Startup only needs the selected skin. In lazy-discovery mode, parse
+        # files in normal precedence order until it is found; menus explicitly
+        # refresh the complete catalog when they are opened.
+        if not skin_info and not self.available_skins:
+            for skin_path in self._iter_skin_files():
+                skin_data = self.loader.load_skin(skin_path)
+                if not skin_data:
+                    continue
+                candidate = self._skin_info(skin_path, skin_data)
+                self.available_skins.append(candidate)
+                if candidate['name'] == skin_name:
+                    skin_info = candidate
+                    break
 
         if not skin_info:
             print(f"Skin not found: {skin_name}")

--- a/taggui/utils/ModelThread.py
+++ b/taggui/utils/ModelThread.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from datetime import datetime
 from time import perf_counter
 import subprocess
+from typing import TYPE_CHECKING
 
-import numpy as np
 from PIL import UnidentifiedImageError
-from transformers import BatchFeature
 from PySide6.QtCore import QModelIndex, QThread, Qt, Signal
 
 from utils.image import Image
 from models.image_list_model import ImageListModel
+
+if TYPE_CHECKING:
+    import numpy as np
+    from transformers import BatchFeature
 
 def format_duration(seconds: float) -> str:
     seconds_per_minute = 60

--- a/taggui/utils/grammar_checker.py
+++ b/taggui/utils/grammar_checker.py
@@ -6,13 +6,10 @@ Provides on-demand grammar, style, and punctuation checking.
 
 from dataclasses import dataclass
 from enum import Enum
+from importlib.util import find_spec
 from typing import List, Optional
 
-try:
-    import language_tool_python
-    LANGUAGE_TOOL_AVAILABLE = True
-except ImportError:
-    LANGUAGE_TOOL_AVAILABLE = False
+LANGUAGE_TOOL_AVAILABLE = find_spec('language_tool_python') is not None
 
 
 class GrammarCheckMode(Enum):
@@ -61,7 +58,7 @@ class GrammarChecker:
                  language: str = 'en-US'):
         self.mode = mode
         self.language = language
-        self._tool: Optional[language_tool_python.LanguageTool] = None
+        self._tool: Optional[object] = None
 
         if not LANGUAGE_TOOL_AVAILABLE:
             self.mode = GrammarCheckMode.DISABLED
@@ -75,6 +72,8 @@ class GrammarChecker:
             return
 
         try:
+            import language_tool_python
+
             if self.mode == GrammarCheckMode.FREE_API:
                 # Use public API (requires internet)
                 self._tool = language_tool_python.LanguageToolPublicAPI(self.language)

--- a/taggui/utils/image_index_db.py
+++ b/taggui/utils/image_index_db.py
@@ -2805,14 +2805,20 @@ class ImageIndexDB:
                 return
 
     def close(self):
-        """Close database connection."""
-        if self.conn:
+        """Close the database connection after any in-flight operation finishes."""
+        with self._db_lock:
+            conn = self.conn
+            self.conn = None
+            if conn is None:
+                return
             try:
-                self.conn.commit()
-                self.conn.close()
+                conn.commit()
             except sqlite3.Error:
                 pass
-            self.conn = None
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
     def __del__(self):
         """Ensure connection is closed on deletion."""
@@ -4187,7 +4193,7 @@ class ImageIndexDB:
 
     def update_image_dimensions(self, file_name: str, width: int, height: int):
         """Persist dimensions for an existing DB row without disturbing other metadata."""
-        if not self.enabled or not self.conn:
+        if not self.enabled:
             return
 
         if not file_name:
@@ -4213,8 +4219,11 @@ class ImageIndexDB:
         aspect_ratio = width / height if height > 0 else 1.0
 
         with self._db_lock:
+            conn = self.conn
+            if conn is None:
+                return
             try:
-                cursor = self.conn.cursor()
+                cursor = conn.cursor()
                 cursor.execute(
                     '''
                     UPDATE images
@@ -4223,7 +4232,7 @@ class ImageIndexDB:
                     ''',
                     (width, height, aspect_ratio, normalized_file_name),
                 )
-                self.conn.commit()
+                conn.commit()
             except sqlite3.Error as e:
                 print(f'Database image dimension write error: {e}')
 

--- a/taggui/utils/settings_widgets.py
+++ b/taggui/utils/settings_widgets.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (QComboBox, QDoubleSpinBox, QLineEdit,
                                QPlainTextEdit, QSlider, QSpinBox)
 
@@ -110,10 +110,32 @@ class SettingsPlainTextEdit(QPlainTextEdit):
         # Add spell checking if enabled
         spell_check_enabled = settings.value('spell_check_enabled', defaultValue=True, type=bool)
         self.spell_highlighter = SpellHighlighter(self.document())
-        self.spell_highlighter.set_enabled(spell_check_enabled)
+        self._spell_check_user_enabled = spell_check_enabled
+        # Prompt editors are populated before the window is shown. Delay the
+        # dictionary and first full-document pass until the user enters one.
+        self.spell_highlighter.set_enabled(False)
+        self._spell_check_activation_timer = QTimer(self)
+        self._spell_check_activation_timer.setSingleShot(True)
+        self._spell_check_activation_timer.setInterval(450)
+        self._spell_check_activation_timer.timeout.connect(
+            self._activate_spell_check
+        )
 
         # Load custom dictionary
         custom_dict_list = settings.value('spell_check_custom_dictionary', [], type=list)
         if custom_dict_list:
             custom_dict = set(custom_dict_list)
             self.spell_highlighter.load_custom_dictionary(custom_dict)
+
+    def focusInEvent(self, event):
+        super().focusInEvent(event)
+        if self._spell_check_user_enabled and not self.spell_highlighter.enabled:
+            self._spell_check_activation_timer.start()
+
+    def _activate_spell_check(self):
+        if (
+            self.hasFocus()
+            and self._spell_check_user_enabled
+            and not self.spell_highlighter.enabled
+        ):
+            self.spell_highlighter.set_enabled(True)

--- a/taggui/utils/spell_highlighter.py
+++ b/taggui/utils/spell_highlighter.py
@@ -5,16 +5,22 @@ Provides red underlines for misspelled words with context menu suggestions.
 """
 
 import re
+from functools import lru_cache
+from importlib.util import find_spec
 from typing import Set
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
 
-try:
+SPELL_CHECKER_AVAILABLE = find_spec("spellchecker") is not None
+
+
+@lru_cache(maxsize=8)
+def _get_spell_checker(language: str):
+    """Share immutable language dictionaries between editor highlighters."""
     from spellchecker import SpellChecker
-    SPELL_CHECKER_AVAILABLE = True
-except ImportError:
-    SPELL_CHECKER_AVAILABLE = False
+
+    return SpellChecker(language=language)
 
 
 class SpellHighlighter(QSyntaxHighlighter):
@@ -30,26 +36,29 @@ class SpellHighlighter(QSyntaxHighlighter):
 
     def __init__(self, parent=None, language='en', custom_words: Set[str] = None):
         super().__init__(parent)
-
-        if not SPELL_CHECKER_AVAILABLE:
-            # Graceful degradation if spell checker not installed
-            self.enabled = False
-            return
-
-        self.enabled = True
-        self.spell_checker = SpellChecker(language=language)
-
-        # Custom dictionary for whitelisted words
+        self.enabled = SPELL_CHECKER_AVAILABLE
+        self._language = language
+        self.spell_checker = None
         self.custom_words = set(custom_words) if custom_words else set()
 
-        # Format for misspelled words (red wavy underline)
         self.error_format = QTextCharFormat()
         self.error_format.setUnderlineColor(QColor(Qt.red))
         self.error_format.setUnderlineStyle(QTextCharFormat.UnderlineStyle.WaveUnderline)
 
+    def _ensure_spell_checker(self):
+        if self.spell_checker is None and SPELL_CHECKER_AVAILABLE:
+            self.spell_checker = _get_spell_checker(self._language)
+        return self.spell_checker
+
     def highlightBlock(self, text):
         """Highlight misspelled words in the given text block."""
         if not self.enabled:
+            return
+
+        if self.WORD_PATTERN.search(text) is None:
+            return
+        spell_checker = self._ensure_spell_checker()
+        if spell_checker is None:
             return
 
         # Find all words in the text
@@ -72,14 +81,14 @@ class SpellHighlighter(QSyntaxHighlighter):
                 for part in parts:
                     if len(part) <= 2:  # Skip short parts
                         continue
-                    if part.lower() not in self.custom_words and self.spell_checker.unknown([part.lower()]):
+                    if part.lower() not in self.custom_words and spell_checker.unknown([part.lower()]):
                         all_valid = False
                         break
                 if all_valid:
                     continue
 
             # Check spelling (case-insensitive)
-            if self.spell_checker.unknown([word.lower()]):
+            if spell_checker.unknown([word.lower()]):
                 # Mark as misspelled
                 self.setFormat(match.start(), match.end() - match.start(),
                              self.error_format)
@@ -100,8 +109,12 @@ class SpellHighlighter(QSyntaxHighlighter):
         if not self.enabled:
             return []
 
+        spell_checker = self._ensure_spell_checker()
+        if spell_checker is None:
+            return []
+
         # Get candidates from spell checker
-        candidates = self.spell_checker.candidates(word.lower())
+        candidates = spell_checker.candidates(word.lower())
 
         if not candidates:
             return []
@@ -121,12 +134,16 @@ class SpellHighlighter(QSyntaxHighlighter):
         if word.lower() in self.custom_words:
             return False
 
+        spell_checker = self._ensure_spell_checker()
+        if spell_checker is None:
+            return False
+
         # Check with spell checker
-        return bool(self.spell_checker.unknown([word.lower()]))
+        return bool(spell_checker.unknown([word.lower()]))
 
     def set_enabled(self, enabled: bool):
         """Enable or disable spell checking."""
-        self.enabled = enabled
+        self.enabled = bool(enabled and SPELL_CHECKER_AVAILABLE)
         self.rehighlight()
 
     def save_custom_dictionary(self) -> Set[str]:

--- a/taggui/utils/thumbnail_cache.py
+++ b/taggui/utils/thumbnail_cache.py
@@ -197,12 +197,13 @@ class ThumbnailCache:
         key_string = f"{file_path}_{mtime}_{size}"
         return hashlib.md5(key_string.encode()).hexdigest()
 
-    def _get_cache_path(self, cache_key: str) -> Path:
-        """Get cache file path for a given key."""
+    def _get_cache_path(self, cache_key: str, *, ensure_parent: bool = False) -> Path:
+        """Get a cache path, creating its hash bucket only for writes."""
         # Organize into subdirectories by first 2 chars to avoid too many files in one dir
         subdir = cache_key[:2]
         cache_subdir = self.cache_dir / subdir
-        cache_subdir.mkdir(exist_ok=True)
+        if ensure_parent:
+            cache_subdir.mkdir(parents=True, exist_ok=True)
         return cache_subdir / f"{cache_key}.webp"
 
     def get_thumbnail(self, file_path: Path, mtime: float, size: int) -> QIcon | None:
@@ -241,6 +242,14 @@ class ThumbnailCache:
                 pass
             return None
 
+    def has_thumbnail(self, file_path: Path, mtime: float, size: int) -> bool:
+        """Return whether a cache entry exists without decoding it."""
+        if not self.enabled:
+            return False
+
+        cache_key = self._get_cache_key(file_path, mtime, size)
+        return self._get_cache_path(cache_key).is_file()
+
     def save_thumbnail(self, file_path: Path, mtime: float, size: int, icon: QIcon):
         """Save thumbnail to cache from QIcon (DEPRECATED — prefer save_thumbnail_qimage)."""
         if not self.enabled or icon.isNull():
@@ -248,7 +257,9 @@ class ThumbnailCache:
         try:
             pixmap = icon.pixmap(size, size)
             if not pixmap.isNull():
-                pixmap.save(str(self._get_cache_path(self._get_cache_key(file_path, mtime, size))), 'WEBP', quality=85)
+                cache_key = self._get_cache_key(file_path, mtime, size)
+                cache_path = self._get_cache_path(cache_key, ensure_parent=True)
+                pixmap.save(str(cache_path), 'WEBP', quality=85)
         except Exception as e:
             print(f'[CACHE ERROR] Exception saving {file_path.name}: {type(e).__name__}: {e}')
 
@@ -265,7 +276,7 @@ class ThumbnailCache:
             return
 
         cache_key = self._get_cache_key(file_path, mtime, size)
-        cache_path = self._get_cache_path(cache_key)
+        cache_path = self._get_cache_path(cache_key, ensure_parent=True)
 
         try:
             result = qimage.save(str(cache_path), 'WEBP', quality=85)

--- a/taggui/utils/video/__init__.py
+++ b/taggui/utils/video/__init__.py
@@ -1,9 +1,24 @@
 """Video editing utilities."""
 
-from .frame_editor import FrameEditor
-from .sar_fixer import SARFixer
-from .batch_processor import BatchProcessor
-from .video_editor import VideoEditor
-from .validator import VideoValidator
+from importlib import import_module
 
 __all__ = ['FrameEditor', 'SARFixer', 'BatchProcessor', 'VideoEditor', 'VideoValidator']
+
+_LAZY_EXPORTS = {
+    'FrameEditor': ('.frame_editor', 'FrameEditor'),
+    'SARFixer': ('.sar_fixer', 'SARFixer'),
+    'BatchProcessor': ('.batch_processor', 'BatchProcessor'),
+    'VideoEditor': ('.video_editor', 'VideoEditor'),
+    'VideoValidator': ('.validator', 'VideoValidator'),
+}
+
+
+def __getattr__(name: str):
+    """Resolve video helpers independently instead of importing the full suite."""
+    target = _LAZY_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+    module_name, attribute_name = target
+    value = getattr(import_module(module_name, __name__), attribute_name)
+    globals()[name] = value
+    return value

--- a/taggui/utils/video/playback_backend.py
+++ b/taggui/utils/video/playback_backend.py
@@ -33,24 +33,62 @@ VLC_RUNTIME_ADDED_DIRS = VLC_RUNTIME_BOOTSTRAP_INFO.get('added_dirs', [])
 VLC_RUNTIME_PLUGIN_DIRS = VLC_RUNTIME_BOOTSTRAP_INFO.get('plugin_dirs', [])
 
 MPV_PYTHON_MODULE = None
-try:
-    import mpv as _mpv  # type: ignore
-    MPV_PYTHON_MODULE = _mpv
-    MPV_BACKEND_AVAILABLE = True
-    MPV_BACKEND_ERROR = ''
-except Exception as e:
-    MPV_BACKEND_AVAILABLE = False
-    MPV_BACKEND_ERROR = f'{type(e).__name__}: {e}'
-
+MPV_BACKEND_AVAILABLE = False
+MPV_BACKEND_ERROR = ''
 VLC_PYTHON_MODULE = None
-try:
-    import vlc as _vlc  # type: ignore
-    VLC_PYTHON_MODULE = _vlc
-    VLC_BACKEND_AVAILABLE = True
-    VLC_BACKEND_ERROR = ''
-except Exception as e:
-    VLC_BACKEND_AVAILABLE = False
-    VLC_BACKEND_ERROR = f'{type(e).__name__}: {e}'
+VLC_BACKEND_AVAILABLE = False
+VLC_BACKEND_ERROR = ''
+_BACKEND_LOAD_ATTEMPTED: set[str] = set()
+
+
+def load_playback_backend(backend_name: str):
+    """Load an optional playback runtime only when it is requested."""
+    global MPV_PYTHON_MODULE, MPV_BACKEND_AVAILABLE, MPV_BACKEND_ERROR
+    global VLC_PYTHON_MODULE, VLC_BACKEND_AVAILABLE, VLC_BACKEND_ERROR
+
+    selected = normalize_playback_backend_name(backend_name)
+    if selected in _BACKEND_LOAD_ATTEMPTED:
+        if selected == PLAYBACK_BACKEND_MPV_EXPERIMENTAL:
+            return MPV_PYTHON_MODULE
+        if selected == PLAYBACK_BACKEND_VLC_EXPERIMENTAL:
+            return VLC_PYTHON_MODULE
+        return None
+
+    _BACKEND_LOAD_ATTEMPTED.add(selected)
+    if selected == PLAYBACK_BACKEND_MPV_EXPERIMENTAL:
+        try:
+            import mpv as _mpv  # type: ignore
+            MPV_PYTHON_MODULE = _mpv
+            MPV_BACKEND_AVAILABLE = True
+            MPV_BACKEND_ERROR = ''
+        except Exception as e:
+            MPV_BACKEND_AVAILABLE = False
+            MPV_BACKEND_ERROR = f'{type(e).__name__}: {e}'
+        return MPV_PYTHON_MODULE
+
+    if selected == PLAYBACK_BACKEND_VLC_EXPERIMENTAL:
+        try:
+            import vlc as _vlc  # type: ignore
+            VLC_PYTHON_MODULE = _vlc
+            VLC_BACKEND_AVAILABLE = True
+            VLC_BACKEND_ERROR = ''
+        except Exception as e:
+            VLC_BACKEND_AVAILABLE = False
+            VLC_BACKEND_ERROR = f'{type(e).__name__}: {e}'
+        return VLC_PYTHON_MODULE
+
+    return None
+
+
+def get_playback_backend_status(backend_name: str) -> tuple[bool, str]:
+    """Return availability and load error, probing the requested backend once."""
+    selected = normalize_playback_backend_name(backend_name)
+    load_playback_backend(selected)
+    if selected == PLAYBACK_BACKEND_MPV_EXPERIMENTAL:
+        return MPV_BACKEND_AVAILABLE, MPV_BACKEND_ERROR
+    if selected == PLAYBACK_BACKEND_VLC_EXPERIMENTAL:
+        return VLC_BACKEND_AVAILABLE, VLC_BACKEND_ERROR
+    return True, ''
 
 
 def normalize_playback_backend_name(name: str | None) -> str:
@@ -76,9 +114,15 @@ def resolve_runtime_playback_backend(configured_backend: str | None = None) -> s
     selected = normalize_playback_backend_name(
         configured_backend if configured_backend is not None else get_configured_playback_backend()
     )
-    if selected == PLAYBACK_BACKEND_MPV_EXPERIMENTAL and MPV_BACKEND_AVAILABLE:
+    if (
+        selected == PLAYBACK_BACKEND_MPV_EXPERIMENTAL
+        and load_playback_backend(selected) is not None
+    ):
         return PLAYBACK_BACKEND_MPV_EXPERIMENTAL
-    if selected == PLAYBACK_BACKEND_VLC_EXPERIMENTAL and VLC_BACKEND_AVAILABLE:
+    if (
+        selected == PLAYBACK_BACKEND_VLC_EXPERIMENTAL
+        and load_playback_backend(selected) is not None
+    ):
         return PLAYBACK_BACKEND_VLC_EXPERIMENTAL
     if selected in RUNTIME_SUPPORTED_PLAYBACK_BACKENDS:
         return selected

--- a/taggui/utils/video/validator.py
+++ b/taggui/utils/video/validator.py
@@ -3,9 +3,7 @@
 import subprocess
 import json
 from pathlib import Path
-from typing import Tuple, Optional
-import cv2
-from .ffmpeg_gpu import ffmpeg_base_args
+from typing import Tuple
 
 
 class VideoValidator:
@@ -25,6 +23,8 @@ class VideoValidator:
         """
         try:
             if check_decode:
+                from .ffmpeg_gpu import ffmpeg_base_args
+
                 # More thorough check: try to decode all frames
                 cmd = [
                     *ffmpeg_base_args(),
@@ -109,6 +109,8 @@ class VideoValidator:
         """
         cap = None
         try:
+            import cv2
+
             cap = cv2.VideoCapture(str(video_path))
 
             if not cap.isOpened():

--- a/taggui/version.py
+++ b/taggui/version.py
@@ -2,5 +2,5 @@
 
 APP_NAME = "TagGUI"
 APP_DISPLAY_NAME = "TagGUI Video 1M"
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 

--- a/taggui/widgets/auto_captioner.py
+++ b/taggui/widgets/auto_captioner.py
@@ -1,4 +1,5 @@
 import gc
+import importlib.util
 import sys
 from pathlib import Path
 from time import perf_counter
@@ -19,18 +20,19 @@ from PySide6.QtWidgets import (QAbstractScrollArea, QDockWidget, QFormLayout,
                                QMenu, QStyle, QTabWidget, QSizePolicy,
                                QVBoxLayout, QWidget)
 
-from auto_captioning.captioning_thread import CaptioningThread
 from auto_captioning.model_availability import (
-    MODEL_ARTIFACT_KIND_HUGGINGFACE,
-    MODEL_ARTIFACT_KIND_WD_TAGGER,
     clear_model_availability_cache,
     get_model_install_state,
 )
-from auto_captioning.models.wd_tagger import WdTagger
-from auto_captioning.models.remote import RemoteGen
-from auto_captioning.models_list import MODELS, get_model_class
-from dialogs.caption_multiple_images_dialog import CaptionMultipleImagesDialog
-from dialogs.prompt_history_dialog import PromptHistoryDialog
+from auto_captioning.models_list import (
+    MODEL_KIND_LOCAL,
+    MODEL_KIND_REMOTE,
+    MODEL_KIND_WD_TAGGER,
+    MODELS,
+    get_model_artifact_kind,
+    get_model_download_revision,
+    get_model_kind,
+)
 from models.image_list_model import ImageListModel
 from utils.big_widgets import TallPushButton
 from utils.prompt_history import get_prompt_history
@@ -52,7 +54,6 @@ from utils.settings_widgets import (FocusedScrollSettingsComboBox,
                                     SettingsPlainTextEdit)
 from utils.utils import pluralize
 from widgets.image_list import ImageList
-import torch
 
 try:
     from shiboken6 import isValid as _shiboken_is_valid
@@ -313,13 +314,9 @@ class CaptionSettingsForm:
 
     def __init__(self, *, use_compact_style: bool = False,
                  unload_model_callback=None):
-        try:
-            import bitsandbytes  # noqa: F401
-            self.is_bitsandbytes_available = True
-        except RuntimeError:
-            self.is_bitsandbytes_available = False
-        except Exception:
-            self.is_bitsandbytes_available = False
+        self.is_bitsandbytes_available = (
+            importlib.util.find_spec('bitsandbytes') is not None
+        )
 
         self.use_compact_style = use_compact_style
         self.layout_mode = load_auto_captioner_layout_mode()
@@ -332,6 +329,7 @@ class CaptionSettingsForm:
         self.compact_video_controls_row = None
         self.compact_device_gpu_row = None
         self.tabs_widget = None
+        self._availability_initialized = False
         self.general_tab = None
         self.prompting_tab = None
         self.advanced_tab = None
@@ -910,25 +908,11 @@ class CaptionSettingsForm:
 
     @staticmethod
     def _get_model_artifact_kind(model_id: str) -> str:
-        direct_path = Path(str(model_id or '').strip()).expanduser()
-        if direct_path.is_dir():
-            if ((direct_path / 'model.onnx').is_file()
-                    and (direct_path / 'selected_tags.csv').is_file()):
-                return MODEL_ARTIFACT_KIND_WD_TAGGER
-        model_class = get_model_class(model_id)
-        return getattr(
-            model_class,
-            'model_artifact_kind',
-            MODEL_ARTIFACT_KIND_HUGGINGFACE,
-        )
+        return get_model_artifact_kind(model_id)
 
     @staticmethod
     def _get_model_revision(model_id: str) -> str | None:
-        model_class = get_model_class(model_id)
-        revision_getter = getattr(model_class, 'get_download_revision', None)
-        if callable(revision_getter):
-            return revision_getter(model_id)
-        return None
+        return get_model_download_revision(model_id)
 
     def _get_install_state(self, model_id: str):
         models_directory_path = settings.value(
@@ -963,6 +947,7 @@ class CaptionSettingsForm:
                 Qt.ItemDataRole.ToolTipRole,
             )
         self.refresh_selected_model_status()
+        self._availability_initialized = True
 
     def refresh_selected_model_status(self):
         model_id = str(self.model_combo_box.currentText() or '').strip()
@@ -1376,7 +1361,6 @@ class CaptionSettingsForm:
             root_layout.addWidget(self._build_tabs())
             root_layout.addStretch(1)
         self.show_settings_for_model(self.model_combo_box.currentText())
-        self.refresh_model_availability()
         self.set_load_in_4_bit_visibility(self.device_combo_box.currentText())
         self._page_cache[layout_mode] = page
         return page
@@ -1480,8 +1464,9 @@ class CaptionSettingsForm:
     def _sync_tab_visibility(self, model_id: str):
         if self.tabs_widget is None:
             return
-        is_wd_tagger_model = get_model_class(model_id) == WdTagger
-        is_remote_model = get_model_class(model_id) == RemoteGen
+        model_kind = get_model_kind(model_id)
+        is_wd_tagger_model = model_kind == MODEL_KIND_WD_TAGGER
+        is_remote_model = model_kind == MODEL_KIND_REMOTE
         is_local_model = not is_wd_tagger_model and not is_remote_model
         for idx, visible in (
             (0, True),
@@ -1518,8 +1503,9 @@ class CaptionSettingsForm:
 
     @Slot(str)
     def show_settings_for_model(self, model_id: str):
-        is_wd_tagger_model = get_model_class(model_id) == WdTagger
-        is_remote_model = get_model_class(model_id) == RemoteGen
+        model_kind = get_model_kind(model_id)
+        is_wd_tagger_model = model_kind == MODEL_KIND_WD_TAGGER
+        is_remote_model = model_kind == MODEL_KIND_REMOTE
         is_local_model = not is_wd_tagger_model and not is_remote_model
         lowercase_id = model_id.lower()
         is_qwen_model = ('qwen2.5-vl' in lowercase_id
@@ -1600,8 +1586,9 @@ class CaptionSettingsForm:
     @Slot(str)
     def set_load_in_4_bit_visibility(self, device: str):
         model_id = self.model_combo_box.currentText()
-        is_wd_tagger_model = get_model_class(model_id) == WdTagger
-        is_remote_model = get_model_class(model_id) == RemoteGen
+        model_kind = get_model_kind(model_id)
+        is_wd_tagger_model = model_kind == MODEL_KIND_WD_TAGGER
+        is_remote_model = model_kind == MODEL_KIND_REMOTE
         if is_wd_tagger_model or is_remote_model:
             self.load_in_4_bit_container.setVisible(False)
             return
@@ -1640,7 +1627,7 @@ class CaptionSettingsForm:
         if container is None:
             return
         visible = (
-            get_model_class(self.model_combo_box.currentText()) == RemoteGen
+            get_model_kind(self.model_combo_box.currentText()) == MODEL_KIND_REMOTE
             and self.output_format_combo_box.currentText() == 'Ideogram 4 JSON'
         )
         container.setVisible(visible)
@@ -1894,6 +1881,12 @@ class AutoCaptioner(QDockWidget):
         self.captioning_status_timer.setInterval(500)
         self.captioning_status_timer.timeout.connect(
             self.refresh_captioning_status)
+        self._availability_refresh_timer = QTimer(self)
+        self._availability_refresh_timer.setSingleShot(True)
+        self._availability_refresh_timer.setInterval(1200)
+        self._availability_refresh_timer.timeout.connect(
+            self._initialize_model_availability_ui
+        )
         self.classic_caption_settings_form = None
         self.compact_caption_settings_form = None
         self.caption_settings_form = None
@@ -2039,7 +2032,8 @@ class AutoCaptioner(QDockWidget):
         self.layout_mode = normalized
         self._update_primary_button_text()
         self._update_unload_button_state()
-        self._refresh_model_availability_ui()
+        if self.isVisible():
+            self._refresh_model_availability_ui()
         self.updateGeometry()
         if persist:
             persist_auto_captioner_layout_mode(normalized)
@@ -2301,6 +2295,23 @@ class AutoCaptioner(QDockWidget):
         super().resizeEvent(event)
         self._update_primary_button_text()
 
+    def showEvent(self, event):
+        super().showEvent(event)
+        form = self.caption_settings_form
+        if (
+            form is not None
+            and not form._availability_initialized
+            and not self._availability_refresh_timer.isActive()
+        ):
+            # Populate decorative cache-status icons after the first window
+            # paint instead of delaying it with filesystem/cache scans.
+            self._availability_refresh_timer.start()
+
+    def _initialize_model_availability_ui(self):
+        form = self.caption_settings_form
+        if form is not None and not form._availability_initialized:
+            self._refresh_model_availability_ui()
+
     def _update_primary_button_text(self, *, canceling: bool = False):
         if canceling:
             full_text = 'Canceling Auto-Captioning...'
@@ -2338,8 +2349,7 @@ class AutoCaptioner(QDockWidget):
             if form is None:
                 continue
             model_id = str(form.model_combo_box.currentText() or '')
-            model_class = get_model_class(model_id)
-            is_local_model = model_class not in (WdTagger, RemoteGen)
+            is_local_model = get_model_kind(model_id) == MODEL_KIND_LOCAL
             form.set_unload_button_state(
                 visible=is_local_model,
                 enabled=is_local_model and loaded_model_present and not self.is_captioning,
@@ -2347,13 +2357,16 @@ class AutoCaptioner(QDockWidget):
 
     def _refresh_model_availability_ui(self):
         clear_model_availability_cache()
+        seen_forms = set()
         for form in (
             self.caption_settings_form,
             self.classic_caption_settings_form,
             self.compact_caption_settings_form,
         ):
-            if form is not None:
-                form.refresh_model_availability()
+            if form is None or id(form) in seen_forms:
+                continue
+            seen_forms.add(id(form))
+            form.refresh_model_availability()
 
     @staticmethod
     def _format_memory_bytes(byte_count: int | float | None) -> str:
@@ -2371,6 +2384,9 @@ class AutoCaptioner(QDockWidget):
 
     @staticmethod
     def _cuda_memory_snapshot() -> tuple[int | None, int | None]:
+        torch = sys.modules.get('torch')
+        if torch is None:
+            return None, None
         if not torch.cuda.is_available():
             return None, None
         try:
@@ -2723,6 +2739,8 @@ class AutoCaptioner(QDockWidget):
     @Slot()
     def show_prompt_history(self):
         """Show prompt history dialog."""
+        from dialogs.prompt_history_dialog import PromptHistoryDialog
+
         dialog = PromptHistoryDialog(self)
         dialog.prompt_selected.connect(self.load_prompt_from_history)
         dialog.exec()
@@ -2779,6 +2797,8 @@ class AutoCaptioner(QDockWidget):
         selected_image_count = len(selected_image_indices)
         show_alert_when_finished = False
         if selected_image_count > 1:
+            from dialogs.caption_multiple_images_dialog import CaptionMultipleImagesDialog
+
             confirmation_dialog = CaptionMultipleImagesDialog(
                 selected_image_count)
             reply = confirmation_dialog.exec()
@@ -2807,6 +2827,7 @@ class AutoCaptioner(QDockWidget):
             defaultValue=DEFAULT_SETTINGS['models_directory_path'], type=str)
         models_directory_path = (Path(models_directory_path)
                                  if models_directory_path else None)
+        from auto_captioning.captioning_thread import CaptioningThread
         self.captioning_thread = CaptioningThread(
             self, self.image_list_model, selected_image_indices,
             caption_settings, tag_separator, models_directory_path,
@@ -2903,7 +2924,8 @@ class AutoCaptioner(QDockWidget):
             del model
         gc.collect()
         gc.collect()
-        if torch.cuda.is_available():
+        torch = sys.modules.get('torch')
+        if torch is not None and torch.cuda.is_available():
             try:
                 torch.cuda.synchronize()
             except Exception:

--- a/taggui/widgets/auto_captioner.py
+++ b/taggui/widgets/auto_captioner.py
@@ -292,6 +292,14 @@ class ClickableLabel(QLabel):
         super().mouseReleaseEvent(event)
 
 
+class ModelAvailabilityComboBox(FocusedScrollSettingsComboBox):
+    availability_requested = Signal()
+
+    def showPopup(self):
+        self.availability_requested.emit()
+        super().showPopup()
+
+
 class CaptionSettingsForm:
     MODEL_SETTING_KEY = 'auto_captioner_model_id'
 
@@ -313,7 +321,8 @@ class CaptionSettingsForm:
     }
 
     def __init__(self, *, use_compact_style: bool = False,
-                 unload_model_callback=None):
+                 unload_model_callback=None,
+                 availability_callback=None):
         self.is_bitsandbytes_available = (
             importlib.util.find_spec('bitsandbytes') is not None
         )
@@ -346,10 +355,14 @@ class CaptionSettingsForm:
                 self.MODEL_SETTING_KEY,
                 legacy_model_id or DEFAULT_SETTINGS[self.MODEL_SETTING_KEY],
             )
-        self.model_combo_box = FocusedScrollSettingsComboBox(
+        self.model_combo_box = ModelAvailabilityComboBox(
             key=self.MODEL_SETTING_KEY,
             default=DEFAULT_SETTINGS[self.MODEL_SETTING_KEY],
         )
+        if availability_callback is not None:
+            self.model_combo_box.availability_requested.connect(
+                availability_callback
+            )
         self.model_combo_box.setEditable(True)
         self.model_combo_box.setIconSize(QSize(12, 12))
         model_combo_view = self.model_combo_box.view()
@@ -1881,12 +1894,6 @@ class AutoCaptioner(QDockWidget):
         self.captioning_status_timer.setInterval(500)
         self.captioning_status_timer.timeout.connect(
             self.refresh_captioning_status)
-        self._availability_refresh_timer = QTimer(self)
-        self._availability_refresh_timer.setSingleShot(True)
-        self._availability_refresh_timer.setInterval(1200)
-        self._availability_refresh_timer.timeout.connect(
-            self._initialize_model_availability_ui
-        )
         self.classic_caption_settings_form = None
         self.compact_caption_settings_form = None
         self.caption_settings_form = None
@@ -1961,6 +1968,7 @@ class AutoCaptioner(QDockWidget):
                 normalized == AUTO_CAPTIONER_LAYOUT_MODE_COMPACT
             ),
             unload_model_callback=self.unload_loaded_model,
+            availability_callback=self._initialize_model_availability_ui,
         )
         if normalized == AUTO_CAPTIONER_LAYOUT_MODE_COMPACT:
             self.compact_caption_settings_form = self.caption_settings_form
@@ -2294,18 +2302,6 @@ class AutoCaptioner(QDockWidget):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._update_primary_button_text()
-
-    def showEvent(self, event):
-        super().showEvent(event)
-        form = self.caption_settings_form
-        if (
-            form is not None
-            and not form._availability_initialized
-            and not self._availability_refresh_timer.isActive()
-        ):
-            # Populate decorative cache-status icons after the first window
-            # paint instead of delaying it with filesystem/cache scans.
-            self._availability_refresh_timer.start()
 
     def _initialize_model_availability_ui(self):
         form = self.caption_settings_form

--- a/taggui/widgets/auto_markings.py
+++ b/taggui/widgets/auto_markings.py
@@ -704,11 +704,6 @@ class AutoMarkings(QDockWidget):
         self.marking_settings_form.reset_class_labels_button.clicked.connect(
             self._reset_class_labels
         )
-        QTimer.singleShot(
-            _startup_delay_ms('TAGGUI_AUTO_MARKING_RESTORE_DELAY_MS', 6500),
-            self._restore_model_selection_state,
-        )
-
     def minimumSizeHint(self):
         return QSize(150, 80)
 
@@ -1036,20 +1031,26 @@ class AutoMarkings(QDockWidget):
         self.marking_settings_form.reset_class_labels_button.setEnabled(
             has_model_text
         )
-        if not has_model_text:
-            self.start_cancel_button.setEnabled(False)
+        self.start_cancel_button.setEnabled(has_model_text)
+        if self.is_marking:
             return
-        self.prepare_generation()
+        requested_model_path = (
+            self.marking_settings_form.model_combo_box.currentData()
+        )
+        if requested_model_path is None:
+            self._discard_prepared_model()
+            return
+        runtime_model_path = preferred_runtime_path(
+            Path(requested_model_path)
+        )
+        if not self._prepared_model_matches(runtime_model_path):
+            self._discard_prepared_model()
 
     @Slot()
     def _on_model_activated(self):
-        requested_model_path = self.marking_settings_form.model_combo_box.currentData()
-        if requested_model_path is None:
+        if self.marking_settings_form.model_combo_box.currentData() is None:
             return
-        requested_model_path = Path(requested_model_path)
-        if preferred_runtime_path(requested_model_path) == requested_model_path:
-            if requested_model_path.suffix.lower() == '.pt':
-                self.prepare_generation(interactive=True, purpose='inspect')
+        self.prepare_generation(interactive=True, purpose='inspect')
 
     @Slot(list)
     def _on_models_refreshed(self, model_paths: list[str]):
@@ -1080,12 +1081,6 @@ class AutoMarkings(QDockWidget):
         else:
             # Start marking.
             self.generate_markings()
-
-    @Slot()
-    def _restore_model_selection_state(self):
-        if self.marking_settings_form.model_combo_box.currentData() is None:
-            return
-        self.prepare_generation()
 
     def set_is_marking(self, is_marking: bool):
         self.is_marking = is_marking
@@ -1292,6 +1287,24 @@ class AutoMarkings(QDockWidget):
         if self.marking_settings_form.model_combo_box.findText(relative_text) >= 0:
             self.marking_settings_form.model_combo_box.setCurrentText(relative_text)
 
+    def _prepared_model_matches(self, model_path: Path) -> bool:
+        thread = self.marking_thread
+        if thread is None or thread.model is None or thread.model_path is None:
+            return False
+        try:
+            return (
+                Path(thread.model_path).expanduser().resolve()
+                == Path(model_path).expanduser().resolve()
+            )
+        except (OSError, RuntimeError):
+            return Path(thread.model_path) == Path(model_path)
+
+    def _discard_prepared_model(self):
+        self.marking_thread = None
+        class_table = self.marking_settings_form.class_table
+        class_table.setRowCount(0)
+        self.marking_settings_form.set_class_count(0)
+
     def prepare_generation(self, *, interactive: bool = False, purpose: str = 'run'):
         selected_image_indices = self.image_list.get_selected_image_indices()
         marking_settings = self.marking_settings_form.get_marking_settings()
@@ -1327,6 +1340,15 @@ class AutoMarkings(QDockWidget):
                 self.result_label.show()
                 self.start_cancel_button.setEnabled(True)
                 return
+        runtime_model_path = marking_settings.get('model_path')
+        if (
+            runtime_model_path is not None
+            and self._prepared_model_matches(Path(runtime_model_path))
+        ):
+            self.marking_thread.selected_image_indices = selected_image_indices
+            self.marking_thread.marking_settings = marking_settings
+            self.start_cancel_button.setEnabled(True)
+            return
         from auto_marking.marking_thread import MarkingThread
         self.marking_thread = MarkingThread(
             self, self.image_list_model, selected_image_indices,

--- a/taggui/widgets/auto_markings.py
+++ b/taggui/widgets/auto_markings.py
@@ -30,6 +30,7 @@ from utils.marking_model_security import (
     preferred_runtime_path,
     prompt_resolve_runtime_path,
 )
+from auto_marking.model_cache import get_cached_model_classes
 from utils.settings_widgets import (FocusedScrollSettingsComboBox,
                                     FocusedScrollSettingsDoubleSpinBox,
                                     FocusedScrollSettingsSpinBox,
@@ -769,12 +770,21 @@ class AutoMarkings(QDockWidget):
             return
         self._first_interaction_handled = True
         self.marking_settings_form._ensure_local_model_paths()
-        if (
-            not self.is_marking
-            and self.marking_settings_form.model_combo_box.currentData()
-            is not None
-        ):
-            self.prepare_generation()
+        if self.is_marking:
+            return
+        requested_model_path = (
+            self.marking_settings_form.model_combo_box.currentData()
+        )
+        if requested_model_path is None:
+            return
+        runtime_model_path = preferred_runtime_path(
+            Path(requested_model_path)
+        )
+        cached_classes = get_cached_model_classes(runtime_model_path)
+        if cached_classes is not None:
+            self._populate_model_categories(cached_classes)
+            return
+        self.prepare_generation()
 
     def wheelEvent(self, event):
         if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
@@ -1094,7 +1104,15 @@ class AutoMarkings(QDockWidget):
 
     @Slot()
     def _on_model_activated(self):
-        if self.marking_settings_form.model_combo_box.currentData() is None:
+        requested_model_path = (
+            self.marking_settings_form.model_combo_box.currentData()
+        )
+        if requested_model_path is None:
+            return
+        runtime_model_path = preferred_runtime_path(Path(requested_model_path))
+        cached_classes = get_cached_model_classes(runtime_model_path)
+        if cached_classes is not None:
+            self._populate_model_categories(cached_classes)
             return
         self.prepare_generation(interactive=True, purpose='inspect')
 
@@ -1494,8 +1512,13 @@ class AutoMarkings(QDockWidget):
             self.result_label.show()
             self.start_cancel_button.setEnabled(True)
             return
+        self._populate_model_categories(thread.model_names)
+        if start_after_prepare:
+            QTimer.singleShot(0, self.generate_markings)
+
+    def _populate_model_categories(self, model_names: dict[int, str]):
+        class_table = self.marking_settings_form.class_table
         previous = class_table.blockSignals(True)
-        model_names = thread.model_names
         try:
             class_table.setRowCount(
                 len(model_names))
@@ -1536,8 +1559,6 @@ class AutoMarkings(QDockWidget):
         self._restore_class_actions_for_current_model()
         self.start_cancel_button.setEnabled(True)
         self.result_label.hide()
-        if start_after_prepare:
-            QTimer.singleShot(0, self.generate_markings)
 
     @Slot(QModelIndex, list)
     def _apply_generated_markings(

--- a/taggui/widgets/auto_markings.py
+++ b/taggui/widgets/auto_markings.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from PySide6.QtCore import Signal, QModelIndex, Qt, Slot, QSize, QEvent
+from PySide6.QtCore import Signal, QModelIndex, Qt, Slot, QTimer, QSize, QEvent
 from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import (QDockWidget, QProgressBar, QPlainTextEdit,
                                QWidget, QVBoxLayout, QScrollArea,
@@ -686,6 +686,8 @@ class AutoMarkings(QDockWidget):
         layout.addWidget(self.run_panel)
         self.setWidget(container)
         self._install_ui_zoom_filters()
+        self._first_interaction_preparation_scheduled = False
+        self._first_interaction_handled = False
         self._apply_ui_zoom()
 
         self.start_cancel_button.clicked.connect(
@@ -722,6 +724,12 @@ class AutoMarkings(QDockWidget):
             child.installEventFilter(self)
 
     def eventFilter(self, watched, event):
+        if event.type() in (
+            QEvent.Type.MouseButtonPress,
+            QEvent.Type.KeyPress,
+            QEvent.Type.Wheel,
+        ):
+            self._schedule_first_interaction_preparation()
         if (
             event.type() == QEvent.Type.Wheel
             and event.modifiers() & Qt.KeyboardModifier.ControlModifier
@@ -732,6 +740,28 @@ class AutoMarkings(QDockWidget):
             event.accept()
             return True
         return super().eventFilter(watched, event)
+
+    def _schedule_first_interaction_preparation(self):
+        if (
+            self._first_interaction_handled
+            or self._first_interaction_preparation_scheduled
+        ):
+            return
+        self._first_interaction_preparation_scheduled = True
+        QTimer.singleShot(0, self._prepare_saved_model_on_first_interaction)
+
+    def _prepare_saved_model_on_first_interaction(self):
+        self._first_interaction_preparation_scheduled = False
+        if self._first_interaction_handled:
+            return
+        self._first_interaction_handled = True
+        self.marking_settings_form._ensure_local_model_paths()
+        if (
+            not self.is_marking
+            and self.marking_settings_form.model_combo_box.currentData()
+            is not None
+        ):
+            self.prepare_generation()
 
     def wheelEvent(self, event):
         if event.modifiers() & Qt.KeyboardModifier.ControlModifier:

--- a/taggui/widgets/auto_markings.py
+++ b/taggui/widgets/auto_markings.py
@@ -1,7 +1,6 @@
-import os
 from pathlib import Path
 
-from PySide6.QtCore import Signal, QModelIndex, Qt, Slot, QTimer, QSize, QEvent
+from PySide6.QtCore import Signal, QModelIndex, Qt, Slot, QSize, QEvent
 from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import (QDockWidget, QProgressBar, QPlainTextEdit,
                                QWidget, QVBoxLayout, QScrollArea,
@@ -38,13 +37,6 @@ from widgets.auto_captioner import set_text_edit_height, restore_stdout_and_stde
 from widgets.image_list import ImageList
 
 
-def _startup_delay_ms(env_name: str, default_ms: int) -> int:
-    try:
-        return max(0, int(os.getenv(env_name, str(default_ms)) or default_ms))
-    except (TypeError, ValueError):
-        return max(0, int(default_ms))
-
-
 class CompressibleAutoMarkingsRoot(QWidget):
     def minimumSizeHint(self):
         return QSize(0, 0)
@@ -56,6 +48,8 @@ class CompressibleScrollArea(QScrollArea):
 
 
 class MarkingModelComboBox(FocusedScrollSettingsComboBox):
+    models_requested = Signal()
+
     _SORT_LABELS = {
         'name': 'Name',
         'recent': 'Recent',
@@ -91,6 +85,7 @@ class MarkingModelComboBox(FocusedScrollSettingsComboBox):
         self._refresh_popup_contents()
 
     def showPopup(self):
+        self.models_requested.emit()
         if self._popup is None:
             self._build_popup()
         self._refresh_popup_contents()
@@ -272,6 +267,10 @@ class MarkingSettingsForm(QWidget):
         self.model_combo_box.setPlaceholderText('Set marking model directory in "Settings..."')
         self.model_combo_box.activated.connect(self._on_model_activated)
         self.model_combo_box.currentTextChanged.connect(self._on_model_text_changed)
+        self.model_combo_box.models_requested.connect(
+            self._ensure_local_model_paths
+        )
+        self._models_loaded = False
         model_selector = QWidget()
         model_selector.setObjectName('autoMarkingsModelRow')
         model_selector_layout = QHBoxLayout(model_selector)
@@ -298,10 +297,6 @@ class MarkingSettingsForm(QWidget):
         self.scan_model_button.clicked.connect(self.open_selected_model_on_virustotal)
         model_selector_layout.addWidget(self.scan_model_button)
         root.addWidget(model_selector)
-        QTimer.singleShot(
-            _startup_delay_ms('TAGGUI_AUTO_MARKING_STARTUP_DELAY_MS', 6000),
-            self.get_local_model_paths,
-        )
         settings.change.connect(lambda key, value: self.get_local_model_paths()
             if key == 'marking_models_directory_path' else 0)
         self.model_warning_label = QLabel()
@@ -444,6 +439,7 @@ class MarkingSettingsForm(QWidget):
         self.model_warning_label.setVisible(bool(warning_text))
 
     def get_local_model_paths(self):
+        self._models_loaded = True
         models_directory_path = settings.value(
             'marking_models_directory_path',
             defaultValue=DEFAULT_SETTINGS['marking_models_directory_path'],
@@ -505,6 +501,10 @@ class MarkingSettingsForm(QWidget):
         if current_path != previous_path or current_text != previous_text:
             self.model_selected.emit(bool(current_text))
         return relative_paths
+
+    def _ensure_local_model_paths(self):
+        if not self._models_loaded:
+            self.get_local_model_paths()
 
     @Slot()
     def open_selected_model_on_virustotal(self):

--- a/taggui/widgets/auto_markings.py
+++ b/taggui/widgets/auto_markings.py
@@ -29,6 +29,7 @@ from utils.marking_model_security import (
     passive_model_warning_text,
     preferred_runtime_path,
     prompt_resolve_runtime_path,
+    resolve_marking_model_value,
 )
 from auto_marking.model_cache import get_cached_model_classes
 from utils.settings_widgets import (FocusedScrollSettingsComboBox,
@@ -720,6 +721,8 @@ class AutoMarkings(QDockWidget):
         self.marking_settings_form.reset_class_labels_button.clicked.connect(
             self._reset_class_labels
         )
+        QTimer.singleShot(0, self._restore_cached_categories_for_saved_model)
+
     def minimumSizeHint(self):
         return QSize(150, 80)
 
@@ -785,6 +788,38 @@ class AutoMarkings(QDockWidget):
             self._populate_model_categories(cached_classes)
             return
         self.prepare_generation()
+
+    def _restore_cached_categories_for_saved_model(self):
+        model_value = str(
+            settings.value('marking_model_id', '', type=str) or ''
+        ).strip()
+        models_root = str(
+            settings.value(
+                'marking_models_directory_path',
+                DEFAULT_SETTINGS['marking_models_directory_path'],
+                type=str,
+            ) or ''
+        ).strip()
+        if not model_value or not models_root:
+            return
+        requested_model_path = resolve_marking_model_value(
+            model_value,
+            models_root,
+        )
+        runtime_model_path = preferred_runtime_path(requested_model_path)
+        cached_classes = get_cached_model_classes(runtime_model_path)
+        if cached_classes is None:
+            return
+
+        try:
+            modified_ns = requested_model_path.stat().st_mtime_ns
+        except OSError:
+            modified_ns = 0
+        self.marking_settings_form.model_combo_box.set_model_entries(
+            [(model_value, requested_model_path, modified_ns)],
+            selected_text=model_value,
+        )
+        self._populate_model_categories(cached_classes)
 
     def wheelEvent(self, event):
         if event.modifiers() & Qt.KeyboardModifier.ControlModifier:

--- a/taggui/widgets/auto_markings.py
+++ b/taggui/widgets/auto_markings.py
@@ -36,8 +36,6 @@ from utils.settings_widgets import (FocusedScrollSettingsComboBox,
                                     SettingsBigCheckBox)
 from widgets.auto_captioner import set_text_edit_height, restore_stdout_and_stderr
 from widgets.image_list import ImageList
-from auto_marking.marking_thread import MarkingThread
-from dialogs.caption_multiple_images_dialog import CaptionMultipleImagesDialog
 
 
 def _startup_delay_ms(env_name: str, default_ms: int) -> int:
@@ -1329,6 +1327,7 @@ class AutoMarkings(QDockWidget):
                 self.result_label.show()
                 self.start_cancel_button.setEnabled(True)
                 return
+        from auto_marking.marking_thread import MarkingThread
         self.marking_thread = MarkingThread(
             self, self.image_list_model, selected_image_indices,
             marking_settings)
@@ -1481,6 +1480,8 @@ class AutoMarkings(QDockWidget):
                         f'{pluralize('Marking', selected_image_count)}',
             should_ask_for_confirmation=selected_image_count > 1)
         if selected_image_count > 1:
+            from dialogs.caption_multiple_images_dialog import CaptionMultipleImagesDialog
+
             confirmation_dialog = CaptionMultipleImagesDialog(
                 selected_image_count, 'Mark', 'Markings')
             reply = confirmation_dialog.exec()

--- a/taggui/widgets/auto_markings.py
+++ b/taggui/widgets/auto_markings.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from PySide6.QtCore import Signal, QModelIndex, Qt, Slot, QTimer, QSize, QEvent
@@ -563,6 +564,7 @@ class MarkingSettingsForm(QWidget):
 
 class AutoMarkings(QDockWidget):
     marking_generated = Signal(QModelIndex, list)
+    _model_preparation_finished = Signal(int, object)
     _CLASS_ACTIONS_SETTINGS_KEY = CLASS_ACTIONS_SETTINGS_KEY
     _CLASS_LABELS_SETTINGS_KEY = CLASS_LABELS_SETTINGS_KEY
 
@@ -574,6 +576,17 @@ class AutoMarkings(QDockWidget):
         self.image_list = image_list
         self.is_marking = False
         self.marking_thread = None
+        self._model_preparation_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix='taggui-marking-model',
+        )
+        self._model_preparation_token = 0
+        self._model_preparation_path = None
+        self._model_preparation_future = None
+        self._start_after_model_preparation = False
+        self._model_preparation_finished.connect(
+            self._on_model_preparation_finished
+        )
         self.show_alert_when_finished = False
         self._run_marking_count = 0
         self._run_processed_image_count = 0
@@ -1073,7 +1086,10 @@ class AutoMarkings(QDockWidget):
         runtime_model_path = preferred_runtime_path(
             Path(requested_model_path)
         )
-        if not self._prepared_model_matches(runtime_model_path):
+        if (
+            not self._prepared_model_matches(runtime_model_path)
+            and not self._model_preparation_matches(runtime_model_path)
+        ):
             self._discard_prepared_model()
 
     @Slot()
@@ -1329,13 +1345,57 @@ class AutoMarkings(QDockWidget):
         except (OSError, RuntimeError):
             return Path(thread.model_path) == Path(model_path)
 
+    def _model_preparation_matches(self, model_path: Path) -> bool:
+        future = self._model_preparation_future
+        if future is None or future.done() or self._model_preparation_path is None:
+            return False
+        try:
+            return (
+                Path(self._model_preparation_path).expanduser().resolve()
+                == Path(model_path).expanduser().resolve()
+            )
+        except (OSError, RuntimeError):
+            return Path(self._model_preparation_path) == Path(model_path)
+
     def _discard_prepared_model(self):
+        self._model_preparation_token += 1
+        self._model_preparation_path = None
+        self._model_preparation_future = None
+        self._start_after_model_preparation = False
         self.marking_thread = None
         class_table = self.marking_settings_form.class_table
         class_table.setRowCount(0)
         self.marking_settings_form.set_class_count(0)
 
-    def prepare_generation(self, *, interactive: bool = False, purpose: str = 'run'):
+    def _create_marking_thread(
+            self, selected_image_indices, marking_settings):
+        from auto_marking.marking_thread import MarkingThread
+        thread = MarkingThread(
+            self, self.image_list_model, selected_image_indices,
+            marking_settings)
+        thread.text_outputted.connect(self.update_console_text_edit)
+        thread.clear_console_text_edit_requested.connect(
+            self.console_text_edit.clear)
+        thread.marking_generated.connect(self._apply_generated_markings)
+        thread.marking_result.connect(self.update_result_label)
+        thread.progress_bar_update_requested.connect(self.progress_bar.setValue)
+        thread.finished.connect(lambda: self.set_is_marking(False))
+        thread.finished.connect(self._handle_marking_finished)
+        thread.finished.connect(restore_stdout_and_stderr)
+        thread.finished.connect(self.progress_bar.hide)
+        thread.finished.connect(
+            lambda: self.start_cancel_button.setEnabled(True))
+        if self.show_alert_when_finished:
+            thread.finished.connect(self.show_alert)
+        return thread
+
+    def prepare_generation(
+            self,
+            *,
+            interactive: bool = False,
+            purpose: str = 'run',
+            start_after_prepare: bool = False,
+    ) -> bool:
         selected_image_indices = self.image_list.get_selected_image_indices()
         marking_settings = self.marking_settings_form.get_marking_settings()
         requested_model_path = marking_settings.get('requested_model_path')
@@ -1357,7 +1417,7 @@ class AutoMarkings(QDockWidget):
                 self.result_label.setText(str(exc))
                 self.result_label.show()
                 self.start_cancel_button.setEnabled(bool(requested_model_path))
-                return
+                return False
             if (not interactive
                     and Path(marking_settings['model_path']).suffix.lower() == '.pt'):
                 self.marking_thread = None
@@ -1369,7 +1429,7 @@ class AutoMarkings(QDockWidget):
                 )
                 self.result_label.show()
                 self.start_cancel_button.setEnabled(True)
-                return
+                return False
         runtime_model_path = marking_settings.get('model_path')
         if (
             runtime_model_path is not None
@@ -1378,46 +1438,72 @@ class AutoMarkings(QDockWidget):
             self.marking_thread.selected_image_indices = selected_image_indices
             self.marking_thread.marking_settings = marking_settings
             self.start_cancel_button.setEnabled(True)
+            return True
+        if runtime_model_path is None:
+            return False
+        runtime_model_path = Path(runtime_model_path)
+        if self._model_preparation_matches(runtime_model_path):
+            self._start_after_model_preparation |= bool(start_after_prepare)
+            return False
+
+        self._model_preparation_token += 1
+        preparation_token = self._model_preparation_token
+        self._model_preparation_path = runtime_model_path
+        self._start_after_model_preparation = bool(start_after_prepare)
+        thread = self._create_marking_thread(
+            selected_image_indices,
+            marking_settings,
+        )
+        self.start_cancel_button.setEnabled(False)
+        self.result_label.setText('Loading auto-marking model...')
+        self.result_label.show()
+
+        def prepare_model():
+            try:
+                thread.preload_model()
+            except Exception as exc:
+                thread.model = None
+                thread.is_error = True
+                thread.error_message = str(exc)
+            self._model_preparation_finished.emit(
+                preparation_token,
+                thread,
+            )
+
+        self._model_preparation_future = (
+            self._model_preparation_executor.submit(prepare_model)
+        )
+        return False
+
+    @Slot(int, object)
+    def _on_model_preparation_finished(self, preparation_token, thread):
+        if preparation_token != self._model_preparation_token:
             return
-        from auto_marking.marking_thread import MarkingThread
-        self.marking_thread = MarkingThread(
-            self, self.image_list_model, selected_image_indices,
-            marking_settings)
-        self.marking_thread.text_outputted.connect(
-            self.update_console_text_edit)
-        self.marking_thread.clear_console_text_edit_requested.connect(
-            self.console_text_edit.clear)
-        self.marking_thread.marking_generated.connect(
-            self._apply_generated_markings)
-        self.marking_thread.marking_result.connect(
-            self.update_result_label)
-        self.marking_thread.progress_bar_update_requested.connect(
-            self.progress_bar.setValue)
-        self.marking_thread.finished.connect(
-            lambda: self.set_is_marking(False))
-        self.marking_thread.finished.connect(self._handle_marking_finished)
-        self.marking_thread.finished.connect(restore_stdout_and_stderr)
-        self.marking_thread.finished.connect(self.progress_bar.hide)
-        self.marking_thread.finished.connect(
-            lambda: self.start_cancel_button.setEnabled(True))
-        if self.show_alert_when_finished:
-            self.marking_thread.finished.connect(self.show_alert)
-        self.marking_thread.preload_model()
+        self._model_preparation_future = None
+        self._model_preparation_path = None
+        start_after_prepare = self._start_after_model_preparation
+        self._start_after_model_preparation = False
+        self.marking_thread = thread
         class_table = self.marking_settings_form.class_table
-        if self.marking_thread.model is None:
+        if thread.model is None:
             class_table.setRowCount(0)
             self.marking_settings_form.set_class_count(0)
-            self.start_cancel_button.setEnabled(False)
+            self.result_label.setText(
+                thread.error_message or 'Failed to load auto-marking model.'
+            )
+            self.result_label.show()
+            self.start_cancel_button.setEnabled(True)
             return
         previous = class_table.blockSignals(True)
+        model_names = thread.model_names
         try:
             class_table.setRowCount(
-                len(self.marking_thread.model.names))
+                len(model_names))
             self.marking_settings_form.set_class_count(
-                len(self.marking_thread.model.names)
+                len(model_names)
             )
             for row, (class_id, class_name) in enumerate(
-                    self.marking_thread.model.names.items()):
+                    model_names.items()):
                 class_item = QTableWidgetItem(str(class_name))
                 class_item.setData(Qt.ItemDataRole.UserRole, int(class_id))
                 class_item.setFlags(
@@ -1449,6 +1535,9 @@ class AutoMarkings(QDockWidget):
         self._restore_class_labels_for_current_model()
         self._restore_class_actions_for_current_model()
         self.start_cancel_button.setEnabled(True)
+        self.result_label.hide()
+        if start_after_prepare:
+            QTimer.singleShot(0, self.generate_markings)
 
     @Slot(QModelIndex, list)
     def _apply_generated_markings(
@@ -1502,9 +1591,10 @@ class AutoMarkings(QDockWidget):
     @Slot()
     def generate_markings(self):
         selected_image_indices = self.image_list.get_selected_image_indices()
-        self.prepare_generation(interactive=True)
-        if self.marking_thread is None or self.marking_thread.model is None:
-            self.start_cancel_button.setEnabled(False)
+        if not self.prepare_generation(
+            interactive=True,
+            start_after_prepare=True,
+        ):
             return
         self.marking_thread.selected_image_indices = selected_image_indices
         self.marking_thread.marking_settings = self.marking_settings_form.get_marking_settings()
@@ -1514,7 +1604,7 @@ class AutoMarkings(QDockWidget):
         )
         classes = {}
         for row, (class_id, class_name) in enumerate(
-                self.marking_thread.model.names.items()):
+                self.marking_thread.model_names.items()):
             label_item = self.marking_settings_form.class_table.item(row, 1)
             output_label = (
                 label_item.text().strip()

--- a/taggui/widgets/image_list_masonry_incremental_service.py
+++ b/taggui/widgets/image_list_masonry_incremental_service.py
@@ -195,7 +195,13 @@ class MasonryIncrementalService:
             item_width = col_w
             item_height = int(item_width / aspect_ratio)
 
-            shortest_col = min(range(num_cols), key=lambda i: column_heights[i])
+            shortest_col = 0
+            shortest_height = column_heights[0]
+            for column_index in range(1, num_cols):
+                column_height = column_heights[column_index]
+                if column_height < shortest_height:
+                    shortest_col = column_index
+                    shortest_height = column_height
             x = shortest_col * (col_w + spacing)
             y = column_heights[shortest_col]
 
@@ -236,7 +242,13 @@ class MasonryIncrementalService:
 
             # Reverse of shortest-column downward layout: place into the column
             # whose current top boundary is lowest on screen.
-            chosen_col = max(range(num_cols), key=lambda i: column_tops[i])
+            chosen_col = 0
+            chosen_top = column_tops[0]
+            for column_index in range(1, num_cols):
+                column_top = column_tops[column_index]
+                if column_top > chosen_top:
+                    chosen_col = column_index
+                    chosen_top = column_top
             x = chosen_col * (col_w + spacing)
             y = column_tops[chosen_col] - item_height - spacing
 

--- a/taggui/widgets/image_list_view_file_ops_mixin.py
+++ b/taggui/widgets/image_list_view_file_ops_mixin.py
@@ -7,6 +7,13 @@ from utils.sidecar import (
     sidecar_backup_path,
 )
 
+
+def _get_loaded_video_player(main_window):
+    image_viewer = getattr(main_window, 'image_viewer', None)
+    video_player = getattr(image_viewer, 'video_player', None)
+    return video_player if video_player is not None else None
+
+
 class ImageListViewFileOpsMixin:
     def get_selected_proxy_indices(self) -> list[QModelIndex]:
         """Return unique selected proxy indices in visual row order."""
@@ -309,10 +316,11 @@ class ImageListViewFileOpsMixin:
         # Hierarchy: ImageListView -> container -> ImageList (QDockWidget) -> MainWindow
         main_window = self.parent().parent().parent()  # Get main window reference
         video_was_cleaned = False
-        if hasattr(main_window, 'image_viewer') and hasattr(main_window.image_viewer, 'video_player'):
-            video_player = main_window.image_viewer.video_player
-            if video_player.video_path:
-                currently_loaded_path = Path(video_player.video_path)
+        video_player = _get_loaded_video_player(main_window)
+        if video_player is not None:
+            video_path = getattr(video_player, 'video_path', None)
+            if video_path:
+                currently_loaded_path = Path(video_path)
                 # Check if we're deleting the currently loaded video
                 for image in selected_images:
                     if image.path == currently_loaded_path:

--- a/taggui/widgets/image_viewer.py
+++ b/taggui/widgets/image_viewer.py
@@ -27,8 +27,6 @@ from utils.ideogram_caption import (
     ideogram_caption_path,
 )
 from utils.rect import RectPosition
-from widgets.video_player import VideoPlayerWidget
-from widgets.video_controls import VideoControlsWidget
 from widgets.compare_divider_utils import (
     COMPARE_DIVIDER_COLOR,
     COMPARE_DIVIDER_THICKNESS_PX,
@@ -492,9 +490,9 @@ class ImageViewer(QWidget):
 
         self.view.wheelEvent = self.wheelEvent
 
-        # Spawned static-image viewers lazily create video widgets only if a
-        # video is loaded. The main viewer remains eager to preserve startup
-        # playback behavior and MPV prewarm.
+        # Video widgets are created only if a video is loaded. Signal wiring is
+        # attached through video_components_ready for both main and spawned
+        # viewers.
         self.video_player = None
         self.video_controls = None
         self._video_components_connected = False
@@ -643,9 +641,6 @@ class ImageViewer(QWidget):
         self.view.viewport().setMouseTracking(True)
         self.view.installEventFilter(self)
         self.view.viewport().installEventFilter(self)
-        if not self.is_spawned_viewer:
-            self._ensure_video_components()
-
     def set_video_loop_persistence_scope(self, scope: str):
         """Store/apply the loop persistence scope for lazily-created controls."""
         self._video_loop_persistence_scope = str(scope)
@@ -677,11 +672,13 @@ class ImageViewer(QWidget):
         self.video_controls.setGeometry(x_pos, y_pos, controls_width, controls_height)
 
     def _ensure_video_components(self):
-        """Create video-only widgets on demand for spawned static-image viewers."""
+        """Import and create video-only widgets on the first video request."""
         if self.video_player is not None and self.video_controls is not None:
             return
 
         if self.video_player is None:
+            from widgets.video_player import VideoPlayerWidget
+
             self.video_player = VideoPlayerWidget()
             QTimer.singleShot(0, lambda: (
                 self.video_player.prewarm_gl_widget(self.view)
@@ -689,6 +686,8 @@ class ImageViewer(QWidget):
             ))
 
         if self.video_controls is None:
+            from widgets.video_controls import VideoControlsWidget
+
             self.video_controls = VideoControlsWidget(self)
             self.video_controls._is_spawned_owner = self.is_spawned_viewer
             self.video_controls.setVisible(False)

--- a/taggui/widgets/main_window.py
+++ b/taggui/widgets/main_window.py
@@ -22,10 +22,6 @@ from controllers.video_editing_controller import VideoEditingController
 from controllers.toolbar_manager import ToolbarManager
 from controllers.menu_manager import MenuManager
 from controllers.signal_manager import SignalManager
-from dialogs.batch_reorder_tags_dialog import BatchReorderTagsDialog
-from dialogs.find_and_replace_dialog import FindAndReplaceDialog
-from dialogs.export_dialog import ExportDialog
-from dialogs.settings_dialog import SettingsDialog
 from models.image_list_model import ImageListModel
 from models.image_tag_list_model import ImageTagListModel
 from models.proxy_image_list_model import ProxyImageListModel
@@ -71,15 +67,20 @@ from widgets.pipeline_editor import PipelineEditor
 from widgets.image_viewer import ImageViewer
 from widgets.floating_viewer_window import FloatingViewerWindow
 from widgets.floating_viewer_wall_layout import calculate_floating_viewer_wall_layout
-from widgets.fullscreen_viewer_window import FullscreenViewerWindow
-from widgets.media_comparison_widget import MediaComparisonWidget
 from widgets.compare_drag_coordinator import CompareDragCoordinator, CompareTargetCandidate, select_best_target
 from widgets.compare_drop_feedback_overlay import CompareDropFeedbackOverlay
 from widgets.video_sync_coordinator import VideoSyncCoordinator
-from widgets.secondary_browser import SecondaryBrowser
 from widgets.context_switch_manager import ContextSwitchManager
 
 TOKENIZER_DIRECTORY_PATH = Path('clip-vit-base-patch32')
+
+
+def _is_media_comparison_widget(widget) -> bool:
+    """Identify an existing comparison without importing its command-only UI."""
+    comparison_module = sys.modules.get("widgets.media_comparison_widget")
+    if comparison_module is None:
+        return False
+    return isinstance(widget, comparison_module.MediaComparisonWidget)
 
 
 class PerfHudOverlay(QWidget):
@@ -573,7 +574,7 @@ class MainWindow(QMainWindow):
         self.post_deletion_index = None  # Track index to focus after deletion
         self._load_session_id = 0  # Increments per load; used to ignore stale callbacks.
         self._restore_in_progress = False
-        self._secondary_browser: SecondaryBrowser | None = None
+        self._secondary_browser = None
         self._context_switch_manager: ContextSwitchManager | None = None
         self._restore_target_global_rank = -1
         self._directory_restore_selection_path = None
@@ -882,10 +883,6 @@ class MainWindow(QMainWindow):
         # status_bar.setSizeGripEnabled(False)
         # self.image_list_model.cache_warm_progress.connect(self._update_cache_status)
         # QTimer.singleShot(1000, lambda: self._update_cache_status(0, 0))
-
-        # Connect video playback signals to freeze list view during playback
-        self.image_viewer.video_player.playback_started.connect(self._freeze_list_view)
-        self.image_viewer.video_player.playback_paused.connect(self._unfreeze_list_view)
 
         # Unfreeze list view temporarily during user interaction
         # Re-freezes automatically after 200ms of idle if video is playing
@@ -3062,6 +3059,8 @@ class MainWindow(QMainWindow):
         # Keep the central area alive so dock splitter widths do not rebalance
         # while the main viewer is temporarily hosted in the fullscreen window.
         central.setVisible(True)
+
+        from widgets.fullscreen_viewer_window import FullscreenViewerWindow
 
         fullscreen_window = FullscreenViewerWindow(viewer)
         fullscreen_window.closing.connect(self._on_fullscreen_window_closing)
@@ -6466,12 +6465,12 @@ class MainWindow(QMainWindow):
     def _snapshot_window_arrangement_state(self, window: QWidget) -> dict:
         """Capture the state needed to rearrange a floating media window in-place."""
         viewer_states = []
-        allow_fit_restore = not isinstance(window, MediaComparisonWidget)
+        allow_fit_restore = not _is_media_comparison_widget(window)
         candidate_viewers = []
         try:
             if isinstance(window, FloatingViewerWindow):
                 candidate_viewers = [window.viewer]
-            elif isinstance(window, MediaComparisonWidget):
+            elif _is_media_comparison_widget(window):
                 getter = getattr(window, "_active_viewers", None)
                 candidate_viewers = getter() if callable(getter) else []
         except RuntimeError:
@@ -6665,7 +6664,7 @@ class MainWindow(QMainWindow):
                         window,
                         enable_review_slots=False,
                     )
-                elif isinstance(window, MediaComparisonWidget):
+                elif _is_media_comparison_widget(window):
                     try:
                         active_viewers = window._active_viewers()
                     except Exception:
@@ -6688,7 +6687,7 @@ class MainWindow(QMainWindow):
                     active_window.activateWindow()
                     if isinstance(active_window, FloatingViewerWindow):
                         self._activate_floating_action_target(active_window.viewer)
-                    elif isinstance(active_window, MediaComparisonWidget):
+                    elif _is_media_comparison_widget(active_window):
                         getter = getattr(active_window, "_active_viewers", None)
                         active_viewers = getter() if callable(getter) else []
                         if active_viewers:
@@ -6924,8 +6923,10 @@ class MainWindow(QMainWindow):
         target_index: QModelIndex,
         source_index: QModelIndex,
         reference_widget=None,
-    ) -> MediaComparisonWidget | None:
+    ) -> QWidget | None:
         """Spawn an A/B comparison window for two media indices."""
+        from widgets.media_comparison_widget import MediaComparisonWidget
+
         def _proxy_model_for_compare_index(index_like):
             try:
                 model = index_like.model()
@@ -6991,7 +6992,7 @@ class MainWindow(QMainWindow):
         QTimer.singleShot(0, _after_spawn)
         return comp_widget
 
-    def _on_media_comparison_closed(self, comp_widget: MediaComparisonWidget):
+    def _on_media_comparison_closed(self, comp_widget: QWidget):
         closed_viewers = []
         try:
             closed_viewers = list(comp_widget.viewers())
@@ -7977,6 +7978,8 @@ class MainWindow(QMainWindow):
             diagnostic_print("[RESTORE][Browser2] ensure skipped; already exists", detail="verbose")
             return False
         diagnostic_print("[RESTORE][Browser2] ensure creating dock", detail="verbose")
+        from widgets.secondary_browser import SecondaryBrowser
+
         self._secondary_browser = SecondaryBrowser(
             image_width=int(settings.value(
                 'image_list_image_width',
@@ -8924,23 +8927,27 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def export_images_dialog(self):
+        from dialogs.export_dialog import ExportDialog
         export_dialog = ExportDialog(parent=self, image_list=self.image_list)
         export_dialog.exec()
         return
 
     @Slot()
     def show_settings_dialog(self):
+        from dialogs.settings_dialog import SettingsDialog
         settings_dialog = SettingsDialog(parent=self)
         settings_dialog.exec()
 
     @Slot()
     def show_find_and_replace_dialog(self):
+        from dialogs.find_and_replace_dialog import FindAndReplaceDialog
         find_and_replace_dialog = FindAndReplaceDialog(
             parent=self, image_list_model=self.image_list_model)
         find_and_replace_dialog.exec()
 
     @Slot()
     def show_batch_reorder_tags_dialog(self):
+        from dialogs.batch_reorder_tags_dialog import BatchReorderTagsDialog
         batch_reorder_tags_dialog = BatchReorderTagsDialog(
             parent=self, image_list_model=self.image_list_model,
             tag_counter_model=self.tag_counter_model)

--- a/taggui/widgets/masonry_worker.py
+++ b/taggui/widgets/masonry_worker.py
@@ -66,6 +66,7 @@ def _calculate_masonry_layout_impl(items_data, column_width, spacing, num_column
         # Calculate positions
         column_heights = [0] * num_columns
         positioned_items = []
+        column_stride = column_width + spacing
 
         for index, aspect_ratio in items_data:
             # CHECK FOR SPACER
@@ -79,15 +80,14 @@ def _calculate_masonry_layout_impl(items_data, column_width, spacing, num_column
                 
                 # Create a VISUAL item for the spacer so we can paint it (Loading Text) and use it as a trigger
                 full_width = (column_width + spacing) * num_columns - spacing
-                spacer_item = MasonryItem(
-                    index=-2,       # Special index for spacer
-                    x=0,
-                    y=max_h,
-                    width=int(full_width),
-                    height=int(spacer_height),
-                    aspect_ratio=1.0
-                )
-                positioned_items.append(spacer_item)
+                positioned_items.append({
+                    'index': -2,
+                    'x': 0,
+                    'y': max_h,
+                    'width': int(full_width),
+                    'height': int(spacer_height),
+                    'aspect_ratio': 1.0,
+                })
 
                 new_h = max_h + spacer_height
                 for i in range(num_columns):
@@ -112,41 +112,35 @@ def _calculate_masonry_layout_impl(items_data, column_width, spacing, num_column
             item_height = int(item_width / aspect_ratio)
 
             # Find shortest column
-            shortest_col = min(range(num_columns), key=lambda i: column_heights[i])
+            shortest_col = 0
+            shortest_height = column_heights[0]
+            for column_index in range(1, num_columns):
+                column_height = column_heights[column_index]
+                if column_height < shortest_height:
+                    shortest_col = column_index
+                    shortest_height = column_height
 
             # Calculate position
-            x = shortest_col * (column_width + spacing)
+            x = shortest_col * column_stride
             y = column_heights[shortest_col]
 
             # Store positioned item
-            positioned_items.append(MasonryItem(
-                index=index,
-                x=x,
-                y=y,
-                width=item_width,
-                height=item_height,
-                aspect_ratio=aspect_ratio
-            ))
+            positioned_items.append({
+                'index': index,
+                'x': x,
+                'y': y,
+                'width': item_width,
+                'height': item_height,
+                'aspect_ratio': aspect_ratio,
+            })
 
             # Update column height
             column_heights[shortest_col] += item_height + spacing
 
         total_height = max(column_heights) if column_heights else 0
 
-        # Convert items to dicts manually (asdict() can crash on large datasets)
-        items_list = []
-        for item in positioned_items:
-            items_list.append({
-                'index': item.index,
-                'x': item.x,
-                'y': item.y,
-                'width': item.width,
-                'height': item.height,
-                'aspect_ratio': item.aspect_ratio
-            })
-
         result = {
-            'items': items_list,
+            'items': positioned_items,
             'total_height': total_height
         }
 
@@ -172,10 +166,11 @@ def _calculate_masonry_layout_impl(items_data, column_width, spacing, num_column
         }
 
 
-def _get_cache_path(cache_key):
-    """Get cache file path."""
+def _get_cache_path(cache_key, *, ensure_parent=False):
+    """Get a cache path, creating its directory only for a write."""
     cache_dir = Path.home() / '.taggui_cache' / 'masonry'
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    if ensure_parent:
+        cache_dir.mkdir(parents=True, exist_ok=True)
     import hashlib
     key_hash = hashlib.md5(cache_key.encode()).hexdigest()
     return cache_dir / f'{key_hash}.pkl'  # Changed from .json to .pkl
@@ -193,7 +188,7 @@ def _save_to_cache_worker(cache_path, cache_data):
 def _save_to_cache(cache_key, result, items_data, column_width, spacing, num_columns):
     """Save result to cache asynchronously in background thread."""
     try:
-        cache_path = _get_cache_path(cache_key)
+        cache_path = _get_cache_path(cache_key, ensure_parent=True)
         cache_data = {
             'cache_version': MASONRY_CACHE_VERSION,
             'column_width': column_width,

--- a/taggui/widgets/pipeline_editor.py
+++ b/taggui/widgets/pipeline_editor.py
@@ -70,13 +70,12 @@ from utils.pipeline import (
 from utils.settings import DEFAULT_SETTINGS, settings
 from utils.icons import create_chain_link_icon
 from utils.marking_model_security import (
-    configure_ultralytics_marking_runtime,
-    infer_marking_model_task,
     list_marking_model_paths,
     passive_model_warning_text,
     prompt_resolve_runtime_path,
     resolve_marking_model_value,
 )
+from auto_marking.model_cache import get_cached_model_classes
 
 
 STEP_META = {
@@ -1250,21 +1249,18 @@ class PipelineStepCard(QFrame):
             if cached is not None and cached[0] == modified_ns:
                 model_classes = cached[1]
             else:
-                QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-                try:
-                    from ultralytics import YOLO
+                cached_classes = get_cached_model_classes(model_path)
+                if cached_classes is not None:
+                    model_classes = sorted(cached_classes.items())
+                else:
+                    QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+                    try:
+                        from auto_marking.model_cache import load_marking_runtime
 
-                    configure_ultralytics_marking_runtime(model_path)
-                    model = YOLO(
-                        model_path,
-                        task=infer_marking_model_task(model_path),
-                    )
-                    model_classes = [
-                        (int(class_id), str(class_name))
-                        for class_id, class_name in sorted(model.names.items())
-                    ]
-                finally:
-                    QApplication.restoreOverrideCursor()
+                        runtime = load_marking_runtime(model_path)
+                        model_classes = sorted(runtime.model_names.items())
+                    finally:
+                        QApplication.restoreOverrideCursor()
                 self._model_class_cache[cache_key] = (
                     modified_ns,
                     model_classes,

--- a/taggui/widgets/pipeline_editor.py
+++ b/taggui/widgets/pipeline_editor.py
@@ -1405,6 +1405,7 @@ class PipelineEditor(QDockWidget):
         self.store = PipelineStore()
         self.pipelines: list[PipelineDefinition] = []
         self.current_pipeline: PipelineDefinition | None = None
+        self._steps_built_for_pipeline_id: str | None = None
         self._loading = False
         self._save_timer = QTimer(self)
         self._save_timer.setSingleShot(True)
@@ -1639,6 +1640,16 @@ class PipelineEditor(QDockWidget):
         super().resizeEvent(event)
         self._update_compact_visibility()
 
+    def showEvent(self, event):
+        super().showEvent(event)
+        pipeline_id = (
+            str(self.current_pipeline.id)
+            if self.current_pipeline is not None
+            else None
+        )
+        if pipeline_id != self._steps_built_for_pipeline_id:
+            self._rebuild_steps()
+
     def _update_compact_visibility(self):
         scale = self.ui_zoom / 100.0
         effective_height = self.height() / max(0.01, scale)
@@ -1815,11 +1826,16 @@ class PipelineEditor(QDockWidget):
             self._SELECTED_PIPELINE_SETTINGS_KEY,
             self.current_pipeline.id,
         )
-        self._rebuild_steps()
+        if self.isVisible():
+            self._rebuild_steps()
+        else:
+            self.step_list.clear()
+            self._steps_built_for_pipeline_id = None
 
     def _rebuild_steps(self):
         self.step_list.clear()
         if self.current_pipeline is None:
+            self._steps_built_for_pipeline_id = None
             return
         marking_models = self._marking_models()
         caption_models = self._caption_models()
@@ -1841,6 +1857,7 @@ class PipelineEditor(QDockWidget):
             self.step_list.addItem(item)
             self.step_list.setItemWidget(item, row_widget)
         self.step_list.schedule_link_connector_refresh()
+        self._steps_built_for_pipeline_id = str(self.current_pipeline.id)
 
     def _step_card(self, step_id: str):
         for row in range(self.step_list.count()):

--- a/taggui/widgets/video_controls.py
+++ b/taggui/widgets/video_controls.py
@@ -1003,7 +1003,7 @@ class VideoControlsWidget(QWidget):
         self._update_mute_button()
 
         # Initialize skin system
-        self.skin_manager = SkinManager()
+        self.skin_manager = SkinManager(discover_on_init=False)
         # Load saved skin or default
         saved_skin = settings.value('video_player_skin', defaultValue='Classic', type=str)
         if not self.skin_manager.load_skin(saved_skin):

--- a/taggui/widgets/video_player.py
+++ b/taggui/widgets/video_player.py
@@ -2,11 +2,11 @@ import os
 import sys
 import time
 import weakref
-# Set environment variables BEFORE importing cv2
+# These are read when OpenCV is imported lazily for frame-accurate fallback.
 os.environ['OPENCV_FFMPEG_LOGLEVEL'] = '-8'
 os.environ['OPENCV_LOG_LEVEL'] = 'SILENT'
 
-import cv2
+from functools import lru_cache
 from pathlib import Path
 from PySide6.QtCore import Qt, QTimer, Signal, Slot, QUrl, QRect, QMetaObject, Q_ARG
 from PySide6.QtGui import QImage, QPixmap
@@ -16,13 +16,9 @@ from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
 from PySide6.QtOpenGLWidgets import QOpenGLWidget
 from PySide6.QtGui import QOpenGLContext
 
-from utils.video import VideoValidator
+from utils.video import playback_backend
 from utils.video.playback_backend import (
-    MPV_PYTHON_MODULE,
-    MPV_BACKEND_ERROR,
     MPV_RUNTIME_SEARCHED_DIRS,
-    VLC_PYTHON_MODULE,
-    VLC_BACKEND_ERROR,
     VLC_RUNTIME_SEARCHED_DIRS,
     PLAYBACK_BACKEND_MPV_EXPERIMENTAL,
     PLAYBACK_BACKEND_QT_HYBRID,
@@ -31,11 +27,18 @@ from utils.video.playback_backend import (
     resolve_runtime_playback_backend,
 )
 
-# Suppress OpenCV logs
-cv2.setLogLevel(0)
 
-mpv = MPV_PYTHON_MODULE
-vlc = VLC_PYTHON_MODULE
+@lru_cache(maxsize=1)
+def _get_cv2():
+    """Load OpenCV only when frame-accurate fallback operations need it."""
+    import cv2
+
+    cv2.setLogLevel(0)
+    return cv2
+
+
+mpv = None
+vlc = None
 
 VIDEO_DISPLAY_FIT_PRESERVE = 'preserve'
 VIDEO_DISPLAY_FIT_FILL = 'fill'
@@ -184,7 +187,9 @@ class VideoPlayerWidget(QWidget):
         self.consecutive_frame_failures = 0
         self.corruption_warning_shown = False
         self._backend_fallback_warned = False
-        self.configured_playback_backend = PLAYBACK_BACKEND_QT_HYBRID
+        # Reading the preference is cheap; probing optional native runtimes is
+        # deferred until a video is loaded or playback is requested.
+        self.configured_playback_backend = get_configured_playback_backend()
         self.runtime_playback_backend = PLAYBACK_BACKEND_QT_HYBRID
         self.mpv_player = None
         self.mpv_widget = None
@@ -262,8 +267,6 @@ class VideoPlayerWidget(QWidget):
         self._qt_video_source_path = None
         self._qt_startup_expected_ms = 0.0
         self._qt_startup_gate_deadline_monotonic = 0.0
-        self._refresh_backend_selection()
-
         # QMediaPlayer for smooth playback
         self.media_player = QMediaPlayer()
         self.audio_output = QAudioOutput()
@@ -307,21 +310,33 @@ class VideoPlayerWidget(QWidget):
 
         Unsupported selections are safely downgraded.
         """
+        global mpv, vlc
+
         self.configured_playback_backend = get_configured_playback_backend()
         self.runtime_playback_backend = resolve_runtime_playback_backend(self.configured_playback_backend)
+        mpv = playback_backend.MPV_PYTHON_MODULE
+        vlc = playback_backend.VLC_PYTHON_MODULE
 
         if self.runtime_playback_backend != self.configured_playback_backend:
             if not self._backend_fallback_warned:
                 reason = ''
-                if self.configured_playback_backend == 'mpv_experimental' and mpv is None and MPV_BACKEND_ERROR:
-                    reason = f" Reason: {MPV_BACKEND_ERROR}"
+                if (
+                    self.configured_playback_backend == 'mpv_experimental'
+                    and mpv is None
+                    and playback_backend.MPV_BACKEND_ERROR
+                ):
+                    reason = f" Reason: {playback_backend.MPV_BACKEND_ERROR}"
                     if not MPV_RUNTIME_SEARCHED_DIRS and os.name == 'nt':
                         reason += (
                             " Hint: place mpv-1.dll in "
                             "'third_party/mpv/windows-x86_64/' or in 'venv/Scripts/'."
                         )
-                if self.configured_playback_backend == 'vlc_experimental' and vlc is None and VLC_BACKEND_ERROR:
-                    reason = f" Reason: {VLC_BACKEND_ERROR}"
+                if (
+                    self.configured_playback_backend == 'vlc_experimental'
+                    and vlc is None
+                    and playback_backend.VLC_BACKEND_ERROR
+                ):
+                    reason = f" Reason: {playback_backend.VLC_BACKEND_ERROR}"
                     if not VLC_RUNTIME_SEARCHED_DIRS and os.name == 'nt':
                         reason += (
                             " Hint: place libvlc.dll/libvlccore.dll in "
@@ -2282,6 +2297,8 @@ class VideoPlayerWidget(QWidget):
     def _open_capture_silently(self, video_path: Path):
         """Open OpenCV capture while suppressing ffmpeg chatter."""
         import sys
+        cv2 = _get_cv2()
+
         # Safely resolve file descriptors for OS-level suppression.
         # Fall back to sys.__stdout__ if sys.stdout is redirected to a Python
         # object without a fileno() (e.g. during captioning).
@@ -2400,6 +2417,7 @@ class VideoPlayerWidget(QWidget):
                 pass
             return False
         self.cap = cap
+        cv2 = _get_cv2()
         try:
             fps = float(self.cap.get(cv2.CAP_PROP_FPS) or 0.0)
         except Exception:
@@ -3145,6 +3163,7 @@ class VideoPlayerWidget(QWidget):
             return
         if not self._ensure_cap_ready() or not self.cap:
             return
+        cv2 = _get_cv2()
 
         if self.total_frames > 0:
             frame_number = max(0, min(frame_number, self.total_frames - 1))
@@ -3654,6 +3673,7 @@ class VideoPlayerWidget(QWidget):
         """Extract a specific frame as RGB numpy array for processing."""
         if not self._ensure_cap_ready() or not self.cap:
             return None
+        cv2 = _get_cv2()
 
         try:
             target_frame = self.current_frame if frame_number is None else int(frame_number)

--- a/tests/test_auto_markings_lazy_model.py
+++ b/tests/test_auto_markings_lazy_model.py
@@ -24,6 +24,18 @@ class _Button:
         self.enabled = bool(enabled)
 
 
+class _Label:
+    def __init__(self):
+        self.text = ""
+        self.visible = False
+
+    def setText(self, text):
+        self.text = text
+
+    def show(self):
+        self.visible = True
+
+
 class _ClassTable:
     def __init__(self):
         self.row_count = None
@@ -58,6 +70,10 @@ def test_model_selection_change_does_not_prepare_model(tmp_path):
     auto_markings = AutoMarkings.__new__(AutoMarkings)
     auto_markings.is_marking = False
     auto_markings.marking_thread = None
+    auto_markings._model_preparation_future = None
+    auto_markings._model_preparation_path = None
+    auto_markings._model_preparation_token = 0
+    auto_markings._start_after_model_preparation = False
     auto_markings.start_cancel_button = _Button()
     auto_markings.prepare_generation = lambda *args, **kwargs: prepared.append(
         (args, kwargs)
@@ -93,6 +109,52 @@ def test_first_panel_interaction_restores_model_categories():
     assert actions == ["scan", "prepare"]
     assert auto_markings._first_interaction_handled
     assert not auto_markings._first_interaction_preparation_scheduled
+
+
+def test_repeated_prepare_requests_share_one_background_load(tmp_path):
+    model_path = tmp_path / "model.onnx"
+    model_path.touch()
+
+    class PendingFuture:
+        def done(self):
+            return False
+
+    class Executor:
+        def __init__(self):
+            self.submissions = []
+
+        def submit(self, callback):
+            self.submissions.append(callback)
+            return PendingFuture()
+
+    executor = Executor()
+    auto_markings = AutoMarkings.__new__(AutoMarkings)
+    auto_markings.marking_thread = None
+    auto_markings._model_preparation_executor = executor
+    auto_markings._model_preparation_future = None
+    auto_markings._model_preparation_path = None
+    auto_markings._model_preparation_token = 0
+    auto_markings._start_after_model_preparation = False
+    auto_markings.image_list = SimpleNamespace(
+        get_selected_image_indices=lambda: []
+    )
+    auto_markings.marking_settings_form = SimpleNamespace(
+        get_marking_settings=lambda: {
+            "model_path": model_path,
+            "requested_model_path": model_path,
+        }
+    )
+    auto_markings.start_cancel_button = _Button()
+    auto_markings.result_label = _Label()
+    auto_markings._create_marking_thread = (
+        lambda selected, settings: SimpleNamespace(preload_model=lambda: None)
+    )
+
+    assert not auto_markings.prepare_generation()
+    assert not auto_markings.prepare_generation(start_after_prepare=True)
+
+    assert len(executor.submissions) == 1
+    assert auto_markings._start_after_model_preparation
 
 
 def test_prepare_generation_reuses_matching_model(tmp_path):

--- a/tests/test_auto_markings_lazy_model.py
+++ b/tests/test_auto_markings_lazy_model.py
@@ -76,6 +76,25 @@ def test_model_selection_change_does_not_prepare_model(tmp_path):
     assert table.row_count == 0
 
 
+def test_first_panel_interaction_restores_model_categories():
+    actions = []
+    auto_markings = AutoMarkings.__new__(AutoMarkings)
+    auto_markings._first_interaction_preparation_scheduled = True
+    auto_markings._first_interaction_handled = False
+    auto_markings.is_marking = False
+    auto_markings.marking_settings_form = SimpleNamespace(
+        _ensure_local_model_paths=lambda: actions.append("scan"),
+        model_combo_box=SimpleNamespace(currentData=lambda: Path("model.onnx")),
+    )
+    auto_markings.prepare_generation = lambda: actions.append("prepare")
+
+    auto_markings._prepare_saved_model_on_first_interaction()
+
+    assert actions == ["scan", "prepare"]
+    assert auto_markings._first_interaction_handled
+    assert not auto_markings._first_interaction_preparation_scheduled
+
+
 def test_prepare_generation_reuses_matching_model(tmp_path):
     model_path = tmp_path / "model.onnx"
     model_path.touch()

--- a/tests/test_auto_markings_lazy_model.py
+++ b/tests/test_auto_markings_lazy_model.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+ROOT = Path(__file__).resolve().parents[1]
+TAGGUI_ROOT = ROOT / "taggui"
+sys.path.insert(0, str(TAGGUI_ROOT))
+
+from PySide6.QtWidgets import QApplication
+from widgets.auto_markings import AutoMarkings
+
+
+APP = QApplication.instance() or QApplication([])
+
+
+class _Button:
+    def __init__(self):
+        self.enabled = None
+
+    def setEnabled(self, enabled):
+        self.enabled = bool(enabled)
+
+
+class _ClassTable:
+    def __init__(self):
+        self.row_count = None
+
+    def setRowCount(self, row_count):
+        self.row_count = row_count
+
+
+def test_model_selection_change_does_not_prepare_model(tmp_path):
+    model_path = tmp_path / "model.onnx"
+    model_path.touch()
+    prepared = []
+    table = _ClassTable()
+    auto_markings = AutoMarkings.__new__(AutoMarkings)
+    auto_markings.is_marking = False
+    auto_markings.marking_thread = None
+    auto_markings.start_cancel_button = _Button()
+    auto_markings.prepare_generation = lambda *args, **kwargs: prepared.append(
+        (args, kwargs)
+    )
+    auto_markings.marking_settings_form = SimpleNamespace(
+        reset_class_labels_button=_Button(),
+        model_combo_box=SimpleNamespace(currentData=lambda: model_path),
+        class_table=table,
+        set_class_count=lambda count: None,
+    )
+
+    auto_markings._on_model_selection_changed(True)
+
+    assert prepared == []
+    assert auto_markings.start_cancel_button.enabled
+    assert table.row_count == 0
+
+
+def test_prepare_generation_reuses_matching_model(tmp_path):
+    model_path = tmp_path / "model.onnx"
+    model_path.touch()
+    existing_thread = SimpleNamespace(
+        model=object(),
+        model_path=model_path,
+        selected_image_indices=[],
+        marking_settings={},
+    )
+    expected_settings = {
+        "model_path": model_path,
+        "requested_model_path": model_path,
+    }
+    auto_markings = AutoMarkings.__new__(AutoMarkings)
+    auto_markings.marking_thread = existing_thread
+    auto_markings.image_list = SimpleNamespace(
+        get_selected_image_indices=lambda: ["selected"]
+    )
+    auto_markings.start_cancel_button = _Button()
+    auto_markings.marking_settings_form = SimpleNamespace(
+        get_marking_settings=lambda: dict(expected_settings)
+    )
+
+    auto_markings.prepare_generation()
+
+    assert auto_markings.marking_thread is existing_thread
+    assert existing_thread.selected_image_indices == ["selected"]
+    assert existing_thread.marking_settings == expected_settings
+    assert auto_markings.start_cancel_button.enabled

--- a/tests/test_auto_markings_lazy_model.py
+++ b/tests/test_auto_markings_lazy_model.py
@@ -10,7 +10,7 @@ TAGGUI_ROOT = ROOT / "taggui"
 sys.path.insert(0, str(TAGGUI_ROOT))
 
 from PySide6.QtWidgets import QApplication
-from widgets.auto_markings import AutoMarkings
+from widgets.auto_markings import AutoMarkings, MarkingSettingsForm
 
 
 APP = QApplication.instance() or QApplication([])
@@ -30,6 +30,24 @@ class _ClassTable:
 
     def setRowCount(self, row_count):
         self.row_count = row_count
+
+
+def test_marking_directory_scan_waits_for_selector(monkeypatch):
+    scans = []
+    monkeypatch.setattr(
+        MarkingSettingsForm,
+        "get_local_model_paths",
+        lambda self: scans.append("scan"),
+    )
+
+    form = MarkingSettingsForm()
+
+    assert scans == []
+    form.model_combo_box.showPopup()
+    APP.processEvents()
+    assert scans == ["scan"]
+    form.model_combo_box.hidePopup()
+    form.deleteLater()
 
 
 def test_model_selection_change_does_not_prepare_model(tmp_path):

--- a/tests/test_auto_markings_lazy_model.py
+++ b/tests/test_auto_markings_lazy_model.py
@@ -10,6 +10,7 @@ TAGGUI_ROOT = ROOT / "taggui"
 sys.path.insert(0, str(TAGGUI_ROOT))
 
 from PySide6.QtWidgets import QApplication
+import widgets.auto_markings as auto_markings_module
 from widgets.auto_markings import AutoMarkings, MarkingSettingsForm
 
 
@@ -109,6 +110,34 @@ def test_first_panel_interaction_restores_model_categories():
     assert actions == ["scan", "prepare"]
     assert auto_markings._first_interaction_handled
     assert not auto_markings._first_interaction_preparation_scheduled
+
+
+def test_first_panel_interaction_uses_cached_categories(monkeypatch):
+    actions = []
+    monkeypatch.setattr(
+        auto_markings_module,
+        "get_cached_model_classes",
+        lambda path: {0: "person", 1: "hand"},
+    )
+    auto_markings = AutoMarkings.__new__(AutoMarkings)
+    auto_markings._first_interaction_preparation_scheduled = True
+    auto_markings._first_interaction_handled = False
+    auto_markings.is_marking = False
+    auto_markings.marking_settings_form = SimpleNamespace(
+        _ensure_local_model_paths=lambda: actions.append("scan"),
+        model_combo_box=SimpleNamespace(currentData=lambda: Path("model.onnx")),
+    )
+    auto_markings._populate_model_categories = (
+        lambda classes: actions.append(("categories", classes))
+    )
+    auto_markings.prepare_generation = lambda: actions.append("prepare")
+
+    auto_markings._prepare_saved_model_on_first_interaction()
+
+    assert actions == [
+        "scan",
+        ("categories", {0: "person", 1: "hand"}),
+    ]
 
 
 def test_repeated_prepare_requests_share_one_background_load(tmp_path):

--- a/tests/test_auto_markings_lazy_model.py
+++ b/tests/test_auto_markings_lazy_model.py
@@ -140,6 +140,44 @@ def test_first_panel_interaction_uses_cached_categories(monkeypatch):
     ]
 
 
+def test_saved_model_categories_restore_without_panel_interaction(
+        tmp_path, monkeypatch):
+    model_path = tmp_path / "model.onnx"
+    model_path.touch()
+    actions = []
+
+    def setting_value(key, default=None, type=None):
+        if key == "marking_model_id":
+            return model_path.name
+        if key == "marking_models_directory_path":
+            return str(tmp_path)
+        return default
+
+    monkeypatch.setattr(auto_markings_module.settings, "value", setting_value)
+    monkeypatch.setattr(
+        auto_markings_module,
+        "get_cached_model_classes",
+        lambda path: {0: "person", 1: "hand"},
+    )
+    auto_markings = AutoMarkings.__new__(AutoMarkings)
+    auto_markings.marking_settings_form = SimpleNamespace(
+        model_combo_box=SimpleNamespace(
+            set_model_entries=lambda entries, selected_text: actions.append(
+                ("selection", entries, selected_text)
+            )
+        )
+    )
+    auto_markings._populate_model_categories = (
+        lambda classes: actions.append(("categories", classes))
+    )
+
+    auto_markings._restore_cached_categories_for_saved_model()
+
+    assert actions[0][0] == "selection"
+    assert actions[0][2] == model_path.name
+    assert actions[1] == ("categories", {0: "person", 1: "hand"})
+
+
 def test_repeated_prepare_requests_share_one_background_load(tmp_path):
     model_path = tmp_path / "model.onnx"
     model_path.touch()

--- a/tests/test_image_index_db_threading.py
+++ b/tests/test_image_index_db_threading.py
@@ -1,0 +1,79 @@
+import sys
+import threading
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "taggui"))
+
+from taggui.utils.image_index_db import ImageIndexDB
+
+
+class _BlockingCursor:
+    def __init__(self, execute_started: threading.Event, release_execute: threading.Event):
+        self._execute_started = execute_started
+        self._release_execute = release_execute
+
+    def execute(self, _sql, _bindings):
+        self._execute_started.set()
+        if not self._release_execute.wait(timeout=2.0):
+            raise TimeoutError("test did not release the blocked database write")
+
+
+class _BlockingConnection:
+    def __init__(self, execute_started: threading.Event, release_execute: threading.Event):
+        self._execute_started = execute_started
+        self._release_execute = release_execute
+        self.closed = False
+
+    def cursor(self):
+        return _BlockingCursor(self._execute_started, self._release_execute)
+
+    def commit(self):
+        return None
+
+    def close(self):
+        self.closed = True
+
+
+def test_close_waits_for_in_flight_dimension_write(tmp_path):
+    execute_started = threading.Event()
+    release_execute = threading.Event()
+    close_started = threading.Event()
+    close_finished = threading.Event()
+    connection = _BlockingConnection(execute_started, release_execute)
+
+    db = object.__new__(ImageIndexDB)
+    db.enabled = True
+    db._directory_path = tmp_path
+    db._db_lock = threading.RLock()
+    db.conn = connection
+
+    writer = threading.Thread(
+        target=db.update_image_dimensions,
+        args=("image.png", 640, 480),
+    )
+
+    def close_database():
+        close_started.set()
+        db.close()
+        close_finished.set()
+
+    closer = threading.Thread(target=close_database)
+    writer.start()
+    assert execute_started.wait(timeout=1.0)
+
+    closer.start()
+    assert close_started.wait(timeout=1.0)
+    assert not close_finished.wait(timeout=0.05)
+
+    release_execute.set()
+    writer.join(timeout=1.0)
+    closer.join(timeout=1.0)
+
+    assert not writer.is_alive()
+    assert not closer.is_alive()
+    assert close_finished.is_set()
+    assert connection.closed is True
+    assert db.conn is None

--- a/tests/test_lazy_startup_dependencies.py
+++ b/tests/test_lazy_startup_dependencies.py
@@ -1,0 +1,214 @@
+import json
+import os
+from pathlib import Path
+from importlib.util import find_spec
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAGGUI_ROOT = ROOT / "taggui"
+sys.path.insert(0, str(TAGGUI_ROOT))
+
+from auto_captioning import models_list
+from utils import spell_highlighter
+
+
+def test_main_window_import_defers_heavy_media_and_spell_modules():
+    script = """
+import json
+import sys
+import widgets.main_window
+assert not widgets.main_window._is_media_comparison_widget(object())
+print(json.dumps({
+    name: name in sys.modules
+    for name in (
+        "cv2",
+        "multiprocessing",
+        "concurrent.futures.process",
+        "exifread",
+        "imagesize",
+        "spellchecker",
+        "widgets.video_player",
+        "widgets.video_controls",
+        "widgets.media_comparison_widget",
+        "widgets.fullscreen_viewer_window",
+        "widgets.secondary_browser",
+        "skins.engine.skin_manager",
+        "PySide6.QtMultimedia",
+        "dialogs.settings_dialog",
+        "dialogs.export_dialog",
+        "dialogs.find_and_replace_dialog",
+        "dialogs.batch_reorder_tags_dialog",
+        "dialogs.prompt_history_dialog",
+        "dialogs.caption_multiple_images_dialog",
+    )
+}))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(TAGGUI_ROOT)
+    env["QT_QPA_PLATFORM"] = "offscreen"
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    loaded = json.loads(result.stdout.strip())
+    assert not any(loaded.values()), loaded
+
+
+def test_video_player_import_defers_opencv_until_fallback():
+    script = """
+import json
+import sys
+from widgets import video_player
+before = "cv2" in sys.modules
+module_name = video_player._get_cv2().__name__
+print(json.dumps({
+    "before": before,
+    "after": "cv2" in sys.modules,
+    "module_name": module_name,
+    "validator_loaded": "utils.video.validator" in sys.modules,
+}))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(TAGGUI_ROOT)
+    env["QT_QPA_PLATFORM"] = "offscreen"
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    state = json.loads(result.stdout.strip())
+    assert state == {
+        "before": False,
+        "after": True,
+        "module_name": "cv2",
+        "validator_loaded": False,
+    }
+
+
+def test_model_registry_import_does_not_load_ml_frameworks():
+    assert "torch" not in sys.modules
+    assert "transformers" not in sys.modules
+    assert "ultralytics" not in sys.modules
+    assert "auto_captioning.auto_captioning_model" not in sys.modules
+    assert "auto_captioning.captioning_thread" not in sys.modules
+    xcomposer_visible = any("xcomposer2" in model for model in models_list.MODELS)
+    assert xcomposer_visible is (find_spec("gptqmodel") is not None)
+
+
+def test_model_metadata_is_resolved_without_concrete_classes(tmp_path):
+    wd_model = tmp_path / "wd-model"
+    wd_model.mkdir()
+    (wd_model / "model.onnx").touch()
+    (wd_model / "selected_tags.csv").touch()
+
+    assert models_list.get_model_kind("Remote") == models_list.MODEL_KIND_REMOTE
+    assert (
+        models_list.get_model_kind("SmilingWolf/wd-vit-tagger-v3")
+        == models_list.MODEL_KIND_WD_TAGGER
+    )
+    assert (
+        models_list.get_model_kind(str(wd_model))
+        == models_list.MODEL_KIND_WD_TAGGER
+    )
+    assert (
+        models_list.get_model_artifact_kind("Remote")
+        == models_list.MODEL_ARTIFACT_KIND_REMOTE
+    )
+    assert (
+        models_list.get_model_download_revision("vikhyatk/moondream2")
+        == "2024-08-26"
+    )
+
+
+def test_model_class_resolution_uses_expected_lazy_adapter(monkeypatch):
+    resolutions = []
+
+    def fake_load(module_name, class_name):
+        resolutions.append((module_name, class_name))
+        return module_name, class_name
+
+    monkeypatch.setattr(models_list, "_load_model_class", fake_load)
+    models_list.get_model_class.cache_clear()
+    try:
+        assert models_list.get_model_class("Remote") == (
+            "auto_captioning.models.remote",
+            "RemoteGen",
+        )
+        assert models_list.get_model_class(
+            "MiaoshouAI/Florence-2-large-PromptGen-v2.0"
+        ) == (
+            "auto_captioning.models.florence_2",
+            "Florence2Promptgen",
+        )
+        assert models_list.get_model_class(
+            "llava-hf/llava-v1.6-vicuna-13b-hf"
+        ) == (
+            "auto_captioning.models.llava_next",
+            "LlavaNextVicuna",
+        )
+    finally:
+        models_list.get_model_class.cache_clear()
+
+    assert len(resolutions) == 3
+
+
+def test_spell_dictionary_is_shared_per_language():
+    if not spell_highlighter.SPELL_CHECKER_AVAILABLE:
+        return
+    spell_highlighter._get_spell_checker.cache_clear()
+    first = spell_highlighter._get_spell_checker("en")
+    second = spell_highlighter._get_spell_checker("en")
+    assert first is second
+
+
+def test_spell_highlighter_defers_dictionary_until_text_is_checked(monkeypatch):
+    if not spell_highlighter.SPELL_CHECKER_AVAILABLE:
+        return
+
+    calls = []
+
+    class FakeChecker:
+        @staticmethod
+        def unknown(words):
+            return set()
+
+    monkeypatch.setattr(
+        spell_highlighter,
+        "_get_spell_checker",
+        lambda language: calls.append(language) or FakeChecker(),
+    )
+    highlighter = spell_highlighter.SpellHighlighter()
+    assert highlighter.spell_checker is None
+    assert calls == []
+    assert highlighter.is_misspelled("example") is False
+    assert calls == ["en"]
+
+
+def test_video_utility_exports_do_not_import_editing_suite():
+    from utils import video
+
+    assert "utils.video.frame_editor" not in sys.modules
+    assert "utils.video.video_editor" not in sys.modules
+    assert video.VideoValidator.__name__ == "VideoValidator"
+    assert "utils.video.validator" in sys.modules
+    assert "cv2" not in sys.modules
+    assert "utils.video.ffmpeg_gpu" not in sys.modules
+    assert "utils.video.frame_editor" not in sys.modules
+
+
+def test_playback_backend_import_does_not_probe_optional_runtimes():
+    from utils.video import playback_backend
+
+    assert playback_backend.MPV_PYTHON_MODULE is None
+    assert playback_backend.VLC_PYTHON_MODULE is None
+    assert "mpv" not in sys.modules
+    assert "vlc" not in sys.modules

--- a/tests/test_lazy_startup_dependencies.py
+++ b/tests/test_lazy_startup_dependencies.py
@@ -60,6 +60,46 @@ print(json.dumps({
     assert not any(loaded.values()), loaded
 
 
+def test_model_availability_waits_for_model_selector():
+    script = """
+import json
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PySide6.QtWidgets import QApplication
+from widgets.auto_captioner import AutoCaptioner
+
+app = QApplication.instance() or QApplication([])
+refreshes = []
+AutoCaptioner._refresh_model_availability_ui = (
+    lambda self: refreshes.append("refresh")
+)
+dock = AutoCaptioner(None, None)
+dock.show()
+app.processEvents()
+after_show = list(refreshes)
+dock.caption_settings_form.model_combo_box.showPopup()
+app.processEvents()
+print(json.dumps({
+    "after_show": after_show,
+    "after_popup": refreshes,
+}))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(TAGGUI_ROOT)
+    env["QT_QPA_PLATFORM"] = "offscreen"
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    state = json.loads(result.stdout.strip())
+    assert state["after_show"] == []
+    assert state["after_popup"] == ["refresh"]
+
+
 def test_video_player_import_defers_opencv_until_fallback():
     script = """
 import json

--- a/tests/test_lazy_video_components.py
+++ b/tests/test_lazy_video_components.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+import sys
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+ROOT = Path(__file__).resolve().parents[1]
+TAGGUI_ROOT = ROOT / "taggui"
+sys.path.insert(0, str(TAGGUI_ROOT))
+
+from PySide6.QtCore import QSortFilterProxyModel
+from PySide6.QtWidgets import QApplication
+
+from widgets.image_viewer import ImageViewer
+
+
+APP = QApplication.instance() or QApplication([])
+
+
+def test_main_viewer_defers_video_widgets_and_emits_ready_on_creation():
+    viewer = ImageViewer(QSortFilterProxyModel(), is_spawned_viewer=False)
+    ready = []
+    viewer.video_components_ready.connect(ready.append)
+
+    assert viewer.video_player is None
+    assert viewer.video_controls is None
+
+    viewer._ensure_video_components()
+
+    assert viewer.video_player is not None
+    assert viewer.video_controls is not None
+    assert ready == [viewer]
+    player = viewer.video_player
+    player.cleanup(force_gc=False)
+    # Prevent the queued GL prewarm callback from touching a cleaned player
+    # if this test shares a QApplication with later Qt tests.
+    viewer.video_player = None
+    viewer.deleteLater()
+    APP.processEvents()

--- a/tests/test_lazy_video_file_operations.py
+++ b/tests/test_lazy_video_file_operations.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAGGUI_ROOT = ROOT / "taggui"
+sys.path.insert(0, str(TAGGUI_ROOT))
+
+from widgets.image_list_view_file_ops_mixin import _get_loaded_video_player
+
+
+def test_delete_supports_viewer_without_constructed_video_player():
+    main_window = SimpleNamespace(
+        image_viewer=SimpleNamespace(video_player=None)
+    )
+
+    assert _get_loaded_video_player(main_window) is None
+
+
+def test_delete_finds_constructed_video_player():
+    player = SimpleNamespace(video_path=Path("video.mp4"))
+    main_window = SimpleNamespace(
+        image_viewer=SimpleNamespace(video_player=player)
+    )
+
+    assert _get_loaded_video_player(main_window) is player

--- a/tests/test_marking_model_cache.py
+++ b/tests/test_marking_model_cache.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAGGUI_ROOT = ROOT / "taggui"
+sys.path.insert(0, str(TAGGUI_ROOT))
+
+from auto_marking import model_cache
+
+
+def test_class_metadata_persists_and_invalidates_with_model_file(
+        tmp_path, monkeypatch):
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"model-v1")
+    cache_path = tmp_path / "classes.json"
+    monkeypatch.setattr(model_cache, "_METADATA_CACHE_PATH", cache_path)
+    model_cache._RUNTIME_CACHE.clear()
+
+    signature = model_cache._model_signature(model_path)
+    model_cache._write_class_metadata(signature, {0: "person", 1: "hand"})
+
+    assert model_cache.get_cached_model_classes(model_path) == {
+        0: "person",
+        1: "hand",
+    }
+
+    model_path.write_bytes(b"model-v2-with-a-different-size")
+
+    assert model_cache.get_cached_model_classes(model_path) is None
+
+
+def test_runtime_cache_loads_unchanged_model_once(tmp_path, monkeypatch):
+    model_path = tmp_path / "model.onnx"
+    model_path.write_bytes(b"model")
+    loads = []
+
+    class FakeYOLO:
+        def __init__(self, path, task=None):
+            loads.append((Path(path), task))
+            self.names = {0: "person", 1: "hand"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "ultralytics",
+        SimpleNamespace(YOLO=FakeYOLO),
+    )
+    monkeypatch.setattr(
+        model_cache,
+        "configure_ultralytics_marking_runtime",
+        lambda path: None,
+    )
+    monkeypatch.setattr(
+        model_cache,
+        "infer_marking_model_task",
+        lambda path: "detect",
+    )
+    monkeypatch.setattr(
+        model_cache,
+        "_preferred_device",
+        lambda path: "cuda",
+    )
+    monkeypatch.setattr(
+        model_cache,
+        "_METADATA_CACHE_PATH",
+        tmp_path / "classes.json",
+    )
+    model_cache._RUNTIME_CACHE.clear()
+
+    first = model_cache.load_marking_runtime(model_path)
+    second = model_cache.load_marking_runtime(model_path)
+
+    assert first is second
+    assert first.model_names == {0: "person", 1: "hand"}
+    assert len(loads) == 1

--- a/tests/test_masonry_worker.py
+++ b/tests/test_masonry_worker.py
@@ -1,0 +1,73 @@
+from taggui.widgets import masonry_worker
+from taggui.widgets.masonry_worker import calculate_masonry_layout
+
+
+def test_masonry_cache_lookup_does_not_create_directories(monkeypatch, tmp_path):
+    monkeypatch.setattr(masonry_worker.Path, "home", lambda: tmp_path)
+
+    read_path = masonry_worker._get_cache_path("read-only")
+    assert not read_path.parent.exists()
+
+    write_path = masonry_worker._get_cache_path("write", ensure_parent=True)
+    assert write_path.parent.is_dir()
+
+
+def test_masonry_layout_preserves_ties_sanitization_and_spacers():
+    result = calculate_masonry_layout(
+        [
+            (0, 1.0),
+            (1, 2.0),
+            (2, 0.0),
+            (999, ("SPACER", 30)),
+            (3, 4.0),
+        ],
+        column_width=100,
+        spacing=2,
+        num_columns=2,
+    )
+
+    assert result == {
+        "items": [
+            {
+                "index": 0,
+                "x": 0,
+                "y": 0,
+                "width": 100,
+                "height": 100,
+                "aspect_ratio": 1.0,
+            },
+            {
+                "index": 1,
+                "x": 102,
+                "y": 0,
+                "width": 100,
+                "height": 50,
+                "aspect_ratio": 2.0,
+            },
+            {
+                "index": 2,
+                "x": 102,
+                "y": 52,
+                "width": 100,
+                "height": 100,
+                "aspect_ratio": 1.0,
+            },
+            {
+                "index": -2,
+                "x": 0,
+                "y": 154,
+                "width": 202,
+                "height": 30,
+                "aspect_ratio": 1.0,
+            },
+            {
+                "index": 3,
+                "x": 0,
+                "y": 184,
+                "width": 100,
+                "height": 25,
+                "aspect_ratio": 4.0,
+            },
+        ],
+        "total_height": 211,
+    }

--- a/tests/test_skin_manager_lazy.py
+++ b/tests/test_skin_manager_lazy.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAGGUI_ROOT = ROOT / "taggui"
+sys.path.insert(0, str(TAGGUI_ROOT))
+
+from skins.engine import SkinManager
+
+
+def test_lazy_skin_manager_loads_selected_skin_before_full_catalog(monkeypatch):
+    manager = SkinManager(discover_on_init=False)
+
+    assert manager.available_skins == []
+    assert manager.load_skin("Classic")
+    assert manager.get_current_skin_name() == "Classic"
+    assert len(manager.available_skins) == 1
+
+    manager.refresh_available_skins()
+    assert len(manager.available_skins) > 1
+    assert any(skin["name"] == "Classic" for skin in manager.available_skins)
+
+    def unexpected_reload(_skin_dirs):
+        raise AssertionError("unchanged skin catalog should not be reparsed")
+
+    monkeypatch.setattr(manager.loader, "list_available_skins", unexpected_reload)
+    manager.refresh_available_skins()

--- a/tests/test_thumbnail_cache.py
+++ b/tests/test_thumbnail_cache.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from concurrent.futures import Future
+import sys
+import threading
+from types import MethodType
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TAGGUI_ROOT = ROOT / "taggui"
+sys.path.insert(0, str(TAGGUI_ROOT))
+
+from utils.thumbnail_cache import ThumbnailCache
+from models.image_list_model import ImageListModel
+
+
+def test_cache_probe_does_not_create_bucket_or_decode(tmp_path):
+    cache = ThumbnailCache.__new__(ThumbnailCache)
+    cache.enabled = True
+    cache.cache_dir = tmp_path
+
+    image_path = tmp_path / "source.jpg"
+    cache_key = cache._get_cache_key(image_path, 123.0, 512)
+    cache_path = cache._get_cache_path(cache_key)
+
+    assert not cache.has_thumbnail(image_path, 123.0, 512)
+    assert not cache_path.parent.exists()
+
+    cache_path.parent.mkdir()
+    cache_path.touch()
+    assert cache.has_thumbnail(image_path, 123.0, 512)
+
+
+def test_thumbnail_future_cleanup_handles_fast_and_replaced_tasks(tmp_path):
+    tracker = type("Tracker", (), {})()
+    tracker._thumbnail_lock = threading.Lock()
+    tracker._thumbnail_futures = {}
+    tracker._forget_thumbnail_future = MethodType(
+        ImageListModel._forget_thumbnail_future, tracker
+    )
+
+    already_done = Future()
+    already_done.set_result(None)
+    ImageListModel._track_thumbnail_future(
+        tracker, 3, tmp_path / "fast.webp", already_done
+    )
+    assert 3 not in tracker._thumbnail_futures
+
+    old_future = Future()
+    new_future = Future()
+    ImageListModel._track_thumbnail_future(
+        tracker, 7, tmp_path / "old.webp", old_future
+    )
+    ImageListModel._track_thumbnail_future(
+        tracker, 7, tmp_path / "new.webp", new_future
+    )
+    old_future.set_result(None)
+    assert tracker._thumbnail_futures[7][0] is new_future
+    new_future.set_result(None)
+    assert 7 not in tracker._thumbnail_futures


### PR DESCRIPTION
## Summary

- defer machine-learning frameworks, workflow workers, optional video backends, media metadata libraries, and command-only UI until their features are used
- make cached large folders expose page zero immediately and validate/warm remaining data in the background
- reduce masonry CPU, thumbnail filesystem/lookup work, repeated skin parsing, and image-only video initialization
- include the branch's pre-existing database refresh access-violation fix and its threading coverage
- document measurements, architectural boundaries, tradeoffs, and the release verification checklist

## Why

Normal GUI startup was importing and constructing substantial optional subsystems even for image-only use. Large cached folders also materialized all indexed paths before becoming usable, while masonry and thumbnail hot paths repeated avoidable CPU, allocation, and filesystem work.

This change moves that work to existing feature boundaries. It does not remove the underlying behavior: the first use of a deferred feature pays its one-time initialization cost.

## Measured impact

- clean `main_window` import: about 14.0 s to about 0.72–0.75 s
- import + application + unshown main window: about 4.45 s to about 0.70–0.87 s warm
- 250,000-item masonry layout: about 590–624 ms to about 256–301 ms
- 20,000 thumbnail cache path reads: about 3.45 s to about 54 ms
- unchanged repeated skin-catalog opens: about 75 ms to about 0.6–0.7 ms
- first deferred video-component construction: roughly 300+ ms to about 212–217 ms
- 1,000,055-row cached index: page zero usable after about 712 ms without loading every path up front

These are development-machine measurements, not release guarantees.

## Behavior and risk notes

- first use of captioning, marking, video, grammar, metadata enrichment, or a deferred dialog can now pay an import/construction cost
- Auto-Markings restores cached categories without opening an ONNX session; Start loads an unchanged runtime once per application session
- Auto-Markings and pipelines share unchanged runtimes, serialized by a per-model inference lock; each distinct used runtime may retain CPU/GPU memory until application exit
- first-video playback still depends on backend initialization, decoder readiness, keyframes, resolution, storage, and hardware; thumbnails are expected to appear earlier than decoded playback
- unchanged cached folders skip the million-path allocation; changed folders still perform full reconciliation
- Hugging Face cache discovery remains a delayed UI task because moving its shared Qt state across threads needs separate design and testing
- entry-point media runtime discovery and Pillow codec registration intentionally remain eager

## Checks

- focused new regression suite: 27 passed
- final audit full suite: 92 passed, 9 failed
- the same nine failures were present in untouched baseline areas involving compare dragging, masonry submission cadence, sidecar reconciliation, and strict scroll-domain expectations
- detailed manual release checklist: `docs/PERFORMANCE_OPTIMIZATIONS.md`

## Review order

1. `7cda6ae` database refresh access-violation fix (pre-existing branch base)
2. `1a7ec3b` deferred workflow dependencies
3. `0eb16f7` large-folder, masonry, and thumbnail hot paths
4. `9d72b9b` lazy video and command UI
5. `d5a9429` official documentation and audit diary
6. `5211ed9` on-demand Hugging Face model discovery
7. `1178cbd` on-demand Auto-Markings model sessions
8. `fd9532d` on-demand Auto-Markings directory discovery
9. `b1fccc3` first-interaction category preparation
10. `1143c9f` asynchronous deduplicated ONNX preparation
11. `183b8f0` deletion compatibility with the lazy video player
12. `618530b` persistent category metadata and shared runtime cache
13. `7569fe9` automatic saved-category restoration